### PR TITLE
Fix: open original source link as a new tab

### DIFF
--- a/src/meridiano/templates/_article_item.html
+++ b/src/meridiano/templates/_article_item.html
@@ -25,7 +25,7 @@
         <div class="article-link-wrapper">
           <a href="{{ url_for('view_article', article_id=article['id']) }}"
              class="article-link">{{ article['title'] | default("Untitled Article") }}</a>
-          <a href="{{ article['url'] }}" class="article-link-original">
+          <a href="{{ article['url'] }}" class="article-link-original" target="_blank" rel="noopener noreferrer">
             <i class="fas fa-external-link" title="Original Article"></i>
           </a>
           <span class="collections-control" style="margin-left:10px; position: relative;">


### PR DESCRIPTION
The simple matters. With so many new things being added to this project, a tiny detail like a 'target blank' might seem an odd choice to start. But looking into the experience, the behavior to see the source article should have been to keep the server page open in the tab while another one opens with the source requested.
About the code change, nothing to add. The diff tells everything!