### PR TITLE
Articles: multi-select feed filter and multi-key sorting

### DIFF
--- a/src/meridiano/app.py
+++ b/src/meridiano/app.py
@@ -21,6 +21,78 @@ app.secret_key = os.getenv("FLASK_SECRET_KEY", "a_default_secret_key_for_develop
 app.jinja_env.filters["datetimeformat"] = format_datetime
 
 
+# Sortable article fields and their labels, in the order shown in the UI.
+ARTICLE_SORT_FIELDS = {
+    "published_date": "Published Date",
+    "impact_score": "Impact Score",
+    "feed_profile": "Feed",
+    "feed_source": "Source",
+}
+
+
+def _parse_sort_args(sort_by_args, direction_args):
+    """
+    Normalises the repeated sort_by/direction query params into two aligned lists.
+
+    Unknown and duplicated fields are dropped, directions are paired positionally
+    with the fields (defaulting to 'desc'), and an empty result falls back to the
+    default single-key sort.
+    """
+    fields, directions = [], []
+    for index, field in enumerate(sort_by_args):
+        if field not in ARTICLE_SORT_FIELDS or field in fields:
+            continue
+        field_direction = direction_args[index] if index < len(direction_args) else "desc"
+        fields.append(field)
+        directions.append(field_direction if field_direction in ("asc", "desc") else "desc")
+
+    if not fields:
+        return ["published_date"], ["desc"]
+    return fields, directions
+
+
+def _build_sort_options(sort_by, direction):
+    """
+    Builds the state of each sort button: whether it is part of the current sort,
+    its rank, and the sort_by/direction lists its links should produce.
+    """
+    options = []
+    for field, label in ARTICLE_SORT_FIELDS.items():
+        if field in sort_by:
+            index = sort_by.index(field)
+            toggled_direction = list(direction)
+            toggled_direction[index] = "asc" if direction[index] == "desc" else "desc"
+            options.append(
+                {
+                    "field": field,
+                    "label": label,
+                    "active": True,
+                    "rank": index + 1,
+                    "direction": direction[index],
+                    # Clicking an active field flips its direction, keeping its position.
+                    "toggle_sort_by": list(sort_by),
+                    "toggle_direction": toggled_direction,
+                    # The 'x' removes this field from the sort chain.
+                    "remove_sort_by": [f for i, f in enumerate(sort_by) if i != index],
+                    "remove_direction": [d for i, d in enumerate(direction) if i != index],
+                }
+            )
+        else:
+            options.append(
+                {
+                    "field": field,
+                    "label": label,
+                    "active": False,
+                    "rank": None,
+                    "direction": None,
+                    # Clicking an inactive field appends it as the next tie-breaker.
+                    "toggle_sort_by": list(sort_by) + [field],
+                    "toggle_direction": list(direction) + ["desc"],
+                }
+            )
+    return options
+
+
 def process_artciles_content(articles_data):
     return [
         {
@@ -81,11 +153,9 @@ def list_articles():
     page = max(1, page)
     per_page = getattr(config, "ARTICLES_PER_PAGE", 25)
 
-    # --- Sorting ---
-    sort_by = request.args.get("sort_by", "published_date")
-    direction = request.args.get("direction", "desc")
-    if direction not in ["asc", "desc"]:
-        direction = "desc"
+    # --- Sorting (multi-key: fields are applied in the order they appear) ---
+    sort_by, direction = _parse_sort_args(request.args.getlist("sort_by"), request.args.getlist("direction"))
+    sort_options = _build_sort_options(sort_by, direction)
 
     # --- Date Filtering ---
     start_date_str = request.args.get("start_date", "")
@@ -134,8 +204,8 @@ def list_articles():
             end_date = None
             print(f"Warning: Invalid end_date format '{request.args.get('end_date')}'")
 
-    # Feed Profile Filtering
-    current_feed_profile = request.args.get("feed_profile", "")  # Empty means 'All'
+    # Feed Profile Filtering (multi-select). Empty list means 'All'.
+    current_feed_profiles = [p for p in request.args.getlist("feed_profile") if p]
 
     # Search Term Filter
     current_search_term = request.args.get("search", "").strip()  # Get search term, trim whitespace
@@ -144,7 +214,7 @@ def list_articles():
     total_articles = database.get_total_article_count(
         start_date=start_date,
         end_date=end_date,
-        feed_profile=current_feed_profile if current_feed_profile else None,
+        feed_profile=current_feed_profiles if current_feed_profiles else None,
         search_term=current_search_term if current_search_term else None,
     )
 
@@ -156,7 +226,7 @@ def list_articles():
         direction=direction,
         start_date=start_date,
         end_date=end_date,
-        feed_profile=current_feed_profile if current_feed_profile else None,
+        feed_profile=current_feed_profiles if current_feed_profiles else None,
         search_term=current_search_term if current_search_term else None,
     )
 
@@ -186,11 +256,12 @@ def list_articles():
         total_articles=total_articles,  # Filtered total
         current_sort_by=sort_by,
         current_direction=direction,
+        sort_options=sort_options,
         current_start_date=start_date_str,
         current_end_date=end_date_str,
         current_preset=preset,
         available_profiles=available_profiles,
-        current_feed_profile=current_feed_profile,
+        current_feed_profiles=current_feed_profiles,
         current_search_term=current_search_term,
     )
 

--- a/src/meridiano/database.py
+++ b/src/meridiano/database.py
@@ -6,7 +6,7 @@ This replaces the SQLite-based database.py with modern SQLModel operations.
 import json
 import logging
 from datetime import date, datetime, timedelta
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
@@ -19,6 +19,60 @@ from .models import init_db as model_init_db
 logger = logging.getLogger(__name__)
 
 ARTICLES_PER_PAGE_DEFAULT = 25
+
+# Columns articles may be sorted by, keyed by the value used in query strings.
+ARTICLE_SORT_COLUMNS = {
+    "published_date": "published_date",
+    "impact_score": "impact_score",
+    "fetched_at": "fetched_at",
+    "feed_profile": "feed_profile",
+    "feed_source": "feed_source",
+}
+
+
+def _build_article_order_by(
+    sort_by: Union[str, List[str], None],
+    direction: Union[str, List[str], None],
+) -> List[Any]:
+    """
+    Builds the ORDER BY clauses for an article query.
+
+    Both arguments accept a single value or a list, allowing multi-key sorting
+    (e.g. sort_by=["impact_score", "published_date"]). Directions are paired
+    positionally with the sort fields; missing entries default to "desc".
+    Unknown or repeated fields are ignored. Article.id is always appended last
+    so pagination stays stable.
+    """
+    if sort_by is None:
+        fields = []
+    elif isinstance(sort_by, str):
+        fields = [sort_by]
+    else:
+        fields = list(sort_by)
+
+    if direction is None:
+        directions = []
+    elif isinstance(direction, str):
+        directions = [direction]
+    else:
+        directions = list(direction)
+
+    clauses = []
+    seen = set()
+    for index, field in enumerate(fields):
+        attribute = ARTICLE_SORT_COLUMNS.get(field)
+        if attribute is None or field in seen:
+            continue
+        seen.add(field)
+        column = getattr(Article, attribute)
+        field_direction = directions[index] if index < len(directions) else "desc"
+        clauses.append(asc(column) if str(field_direction).lower() == "asc" else desc(column))
+
+    if not clauses:
+        clauses.append(desc(Article.published_date))
+
+    clauses.append(desc(Article.id))
+    return clauses
 
 
 def get_db_connection():
@@ -117,9 +171,13 @@ def _brief_to_dict(brief: Brief) -> Dict[str, Any]:
 def _build_article_filters(
     start_date: Optional[date] = None,
     end_date: Optional[date] = None,
-    feed_profile: Optional[str] = None,
+    feed_profile: Optional[Union[str, List[str]]] = None,
 ):
-    """Helper for building filter conditions for articles."""
+    """Helper for building filter conditions for articles.
+
+    ``feed_profile`` may be a single profile name or a list of names
+    (multi-select). A list filters with ``IN``; a string filters with ``==``.
+    """
     filters = []
 
     if start_date:
@@ -127,7 +185,10 @@ def _build_article_filters(
     if end_date:
         filters.append(func.date(Article.published_date) <= func.date(end_date))
     if feed_profile:
-        filters.append(Article.feed_profile == feed_profile)
+        if isinstance(feed_profile, (list, tuple, set)):
+            filters.append(Article.feed_profile.in_(list(feed_profile)))
+        else:
+            filters.append(Article.feed_profile == feed_profile)
 
     return filters
 
@@ -135,11 +196,11 @@ def _build_article_filters(
 def get_all_articles(
     page: int = 1,
     per_page: int = ARTICLES_PER_PAGE_DEFAULT,
-    sort_by: str = "published_date",
-    direction: str = "desc",
+    sort_by: Union[str, List[str]] = "published_date",
+    direction: Union[str, List[str]] = "desc",
     start_date: Optional[date] = None,
     end_date: Optional[date] = None,
-    feed_profile: Optional[str] = None,
+    feed_profile: Optional[Union[str, List[str]]] = None,
     search_term: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """
@@ -174,18 +235,8 @@ def get_all_articles(
                 )
                 statement = statement.where(search_filter)
 
-        # Apply sorting
-        sort_columns = {
-            "published_date": Article.published_date,
-            "impact_score": Article.impact_score,
-            "fetched_at": Article.fetched_at,
-        }
-
-        sort_column = sort_columns.get(sort_by, Article.published_date)
-        if direction.lower() == "asc":
-            statement = statement.order_by(asc(sort_column), desc(Article.id))
-        else:
-            statement = statement.order_by(desc(sort_column), desc(Article.id))
+        # Apply sorting (one or more keys, applied in the given order)
+        statement = statement.order_by(*_build_article_order_by(sort_by, direction))
 
         # Apply pagination
         offset = (page - 1) * per_page
@@ -198,7 +249,7 @@ def get_all_articles(
 def get_total_article_count(
     start_date: Optional[date] = None,
     end_date: Optional[date] = None,
-    feed_profile: Optional[str] = None,
+    feed_profile: Optional[Union[str, List[str]]] = None,
     search_term: Optional[str] = None,
 ) -> int:
     """Returns total count of articles with optional filtering and search."""

--- a/src/meridiano/static/css/style.css
+++ b/src/meridiano/static/css/style.css
@@ -690,6 +690,45 @@ blockquote {
     color: #343a40; /* Dark color for indicator */
 }
 
+/* Groups a sort key with its remove button */
+.sort-item {
+    display: inline-flex;
+    align-items: center;
+    margin-left: 15px;
+}
+
+.sort-item .sort-link {
+    margin-left: 0;
+}
+
+/* Position of the key in the sort chain (1 = primary) */
+.sort-rank {
+    display: inline-block;
+    min-width: 16px;
+    margin-right: 4px;
+    padding: 0 4px;
+    border-radius: 8px;
+    background-color: #0056b3;
+    color: #fff;
+    font-size: 0.75em;
+    text-align: center;
+}
+
+.sort-remove {
+    margin-left: 4px;
+    padding: 2px 4px;
+    border-radius: 3px;
+    color: #6c757d;
+    font-size: 0.8em;
+    text-decoration: none;
+}
+
+.sort-remove:hover {
+    background-color: #e9ecef;
+    color: #dc3545;
+    text-decoration: none;
+}
+
 /* --- Feed Profile Filter & Badge Styling --- */
 .profile-filter {
     margin-bottom: 15px;
@@ -709,6 +748,68 @@ blockquote {
      font-size: 0.9em;
     color: #495057;
 }
+
+/* Multi-select feed profile chips */
+.profile-filter-label {
+    font-size: 0.9em;
+    color: #495057;
+    margin-right: 8px;
+    font-weight: 500;
+}
+.chip-group {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+    vertical-align: middle;
+}
+.chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 12px;
+    border: 1px solid #ced4da;
+    border-radius: 999px;
+    background-color: #fff;
+    color: #495057;
+    font-size: 0.85em;
+    line-height: 1.3;
+    cursor: pointer;
+    user-select: none;
+    text-decoration: none;
+    transition: background-color 0.15s, border-color 0.15s, color 0.15s;
+}
+.chip:hover {
+    border-color: #adb5bd;
+    background-color: #f1f3f5;
+}
+/* Hide the native checkbox; the whole chip is the control */
+.chip input[type="checkbox"] {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+.chip.chip-active {
+    background-color: #007bff;
+    border-color: #007bff;
+    color: #fff;
+    font-weight: 500;
+}
+.chip.chip-active:hover {
+    background-color: #0069d9;
+    border-color: #0062cc;
+}
+.chip.chip-clear {
+    background-color: transparent;
+    border-style: dashed;
+    color: #6c757d;
+}
+.chip.chip-clear:hover {
+    color: #dc3545;
+    border-color: #dc3545;
+    background-color: transparent;
+}
+
 
 .profile-link {
     text-decoration: none;
@@ -925,3 +1026,35 @@ blockquote {
     color: #6c757d; /* Muted text color */
     margin-left: 5px;
 }
+
+/* Dark theme for the chips and sort controls */
+html[data-theme="dark"] .profile-filter-label { color: #c1c6cd; }
+html[data-theme="dark"] .chip {
+    background-color: #2b2f36;
+    border-color: #495057;
+    color: #c1c6cd;
+}
+html[data-theme="dark"] .chip:hover {
+    background-color: #343a40;
+    border-color: #6c757d;
+}
+html[data-theme="dark"] .chip.chip-active {
+    background-color: #1971c2;
+    border-color: #1971c2;
+    color: #fff;
+}
+html[data-theme="dark"] .chip.chip-active:hover {
+    background-color: #1864ab;
+    border-color: #1864ab;
+}
+html[data-theme="dark"] .chip.chip-clear {
+    background-color: transparent;
+    color: #9aa0a6;
+}
+html[data-theme="dark"] .chip.chip-clear:hover {
+    color: #ff6b6b;
+    border-color: #ff6b6b;
+}
+html[data-theme="dark"] .sort-rank { background-color: #4dabf7; color: #16181c; }
+html[data-theme="dark"] .sort-remove { color: #9aa0a6; }
+html[data-theme="dark"] .sort-remove:hover { background-color: #2b2f36; color: #ff6b6b; }

--- a/src/meridiano/templates/articles.html
+++ b/src/meridiano/templates/articles.html
@@ -119,10 +119,10 @@
                                 {{ option.label }}
                                 {% if option.active %}<span class="sort-indicator">{{ '▲' if option.direction == 'asc' else '▼' }}</span>{% endif %}
                             </a>
-                            {% if option.active and current_sort_by | length > 1 %}
+                            {% if option.active %}
                                 <a href="{{ url_for('list_articles', page=1, sort_by=option.remove_sort_by, direction=option.remove_direction, start_date=current_start_date, end_date=current_end_date, preset=current_preset, feed_profile=current_feed_profiles, search=current_search_term) }}"
                                    class="sort-remove"
-                                   title="Remove this sort key"><i class="fas fa-times"></i></a>
+                                   title="{{ 'Remove this sort key' if option.remove_sort_by else 'Clear the sort and go back to the default' }}"><i class="fas fa-times"></i></a>
                             {% endif %}
                         </span>
                     {% endfor %}

--- a/src/meridiano/templates/articles.html
+++ b/src/meridiano/templates/articles.html
@@ -2,7 +2,7 @@
 <html lang="en">
     {% set title =
         "Articles" ~
-        (current_feed_profile and ("[" ~ current_feed_profile ~ "]") or "") ~
+        (current_feed_profiles and ("[" ~ current_feed_profiles | join(", ") ~ "]") or "") ~
         (current_search_term and (" | Search: " ~ current_search_term) or "") ~
         " (Page " ~ page ~ ")"
     %}
@@ -13,7 +13,7 @@
             {% include 'header.html' %}
             <h2>
                 Articles
-                {% if current_feed_profile %}<span class="profile-badge">{{ current_feed_profile }}</span>{% endif %}
+                {% for profile in current_feed_profiles %}<span class="profile-badge">{{ profile }}</span>{% endfor %}
             </h2>
             {% if total_articles > 0 %}
                 <p>
@@ -25,25 +25,33 @@
             <form method="GET"
                   action="{{ url_for("list_articles") }}"
                   class="filter-sort-form">
-                <input type="hidden" name="sort_by" value="{{ current_sort_by }}">
-                <input type="hidden" name="direction" value="{{ current_direction }}">
+                {% for field in current_sort_by %}
+                    <input type="hidden" name="sort_by" value="{{ field }}">
+                    <input type="hidden" name="direction" value="{{ current_direction[loop.index0] }}">
+                {% endfor %}
                 <input type="hidden" name="start_date" value="{{ current_start_date }}">
                 <input type="hidden" name="end_date" value="{{ current_end_date }}">
                 <input type="hidden" name="preset" value="{{ current_preset }}">
                 <div class="form-row form-section">
                     <div class="profile-filter">
-                        <label for="feed_profile_select">Profile:</label>
-                        <select name="feed_profile"
-                                id="feed_profile_select"
-                                onchange="this.form.submit()">
-                            <option value="" {% if not current_feed_profile %}selected{% endif %}>All Profiles</option>
+                        <span class="profile-filter-label">Profiles:</span>
+                        <div class="chip-group" role="group" aria-label="Filter by feed profile">
                             {% for profile in available_profiles %}
-                                <option value="{{ profile }}"
-                                        {% if current_feed_profile == profile %}selected{% endif %}>
-                                    {{ profile }}
-                                </option>
+                                <label class="chip {% if profile in current_feed_profiles %}chip-active{% endif %}">
+                                    <input type="checkbox"
+                                           name="feed_profile"
+                                           value="{{ profile }}"
+                                           {% if profile in current_feed_profiles %}checked{% endif %}
+                                           onchange="this.form.submit()">
+                                    <span class="chip-label">{{ profile }}</span>
+                                </label>
                             {% endfor %}
-                        </select>
+                            {% if current_feed_profiles %}
+                                <a href="{{ url_for('list_articles', page=1, sort_by=current_sort_by, direction=current_direction, start_date=current_start_date, end_date=current_end_date, preset=current_preset, search=current_search_term) }}"
+                                   class="chip chip-clear"
+                                   title="Show all profiles"><i class="fas fa-times"></i> All</a>
+                            {% endif %}
+                        </div>
                     </div>
                     <div class="search-filter">
                         <input type="search"
@@ -55,7 +63,7 @@
                             <i class="fas fa-search"></i>
                         </button>
                         {% if current_search_term %}
-                            <a href="{{ url_for('list_articles', page=1, sort_by=current_sort_by, direction=current_direction, start_date=current_start_date, end_date=current_end_date, preset=current_preset, feed_profile=current_feed_profile) }}"
+                            <a href="{{ url_for('list_articles', page=1, sort_by=current_sort_by, direction=current_direction, start_date=current_start_date, end_date=current_end_date, preset=current_preset, feed_profile=current_feed_profiles) }}"
                                class="btn btn-clear-search"
                                title="Clear Search"><i class="fas fa-times"></i></a>
                         {% endif %}
@@ -82,7 +90,7 @@
                                    name="end_date"
                                    value="{{ current_end_date }}">
                             <button type="submit" class="btn btn-filter"><i class="fas fa-filter"></i> Apply Filters</button>
-                            <a href="{{ url_for('list_articles', sort_by=current_sort_by, direction=current_direction, feed_profile=current_feed_profile, search=current_search_term) }}"
+                            <a href="{{ url_for('list_articles', sort_by=current_sort_by, direction=current_direction, feed_profile=current_feed_profiles, search=current_search_term) }}"
                                class="btn btn-clear"><i class="fas fa-times-circle"></i> Clear Dates</a>
                         </div>
                         <div class="preset-buttons">
@@ -94,7 +102,7 @@
                                 "last_12m": "Last 12mo"
                             } %}
                             {% for key, label in presets.items() %}
-                                <a href="{{ url_for('list_articles', preset=key, sort_by=current_sort_by, direction=current_direction, feed_profile=current_feed_profile, search=current_search_term) }}"
+                                <a href="{{ url_for('list_articles', preset=key, sort_by=current_sort_by, direction=current_direction, feed_profile=current_feed_profiles, search=current_search_term) }}"
                                    class="btn btn-preset {{ 'active' if current_preset == key else '' }}">{{ label }}</a>
                             {% endfor %}
                         </div>
@@ -102,14 +110,21 @@
                 </div>
                 <div class="sort-controls form-section">
                     Sort by:
-                    {% set sort_fields = {"published_date": "Published Date", "impact_score": "Impact Score"} %}
-                    {% for field, label in sort_fields.items() %}
-                        {% set is_active = (current_sort_by == field) %}
-                        {% set next_direction = 'asc' if (is_active and current_direction == 'desc') else 'desc' %}
-                        <a href="{{ url_for('list_articles', page=1, sort_by=field, direction=next_direction, start_date=current_start_date, end_date=current_end_date, preset=current_preset, feed_profile=current_feed_profile, search=current_search_term) }}"
-                           class="sort-link {{ 'active' if is_active else '' }}">{{ label }}
-                            {% if is_active %}<span class="sort-indicator">{{ '▲' if current_direction == 'asc' else '▼' }}</span>{% endif %}
-                        </a>
+                    {% for option in sort_options %}
+                        <span class="sort-item {{ 'active' if option.active else '' }}">
+                            <a href="{{ url_for('list_articles', page=1, sort_by=option.toggle_sort_by, direction=option.toggle_direction, start_date=current_start_date, end_date=current_end_date, preset=current_preset, feed_profile=current_feed_profiles, search=current_search_term) }}"
+                               class="sort-link {{ 'active' if option.active else '' }}"
+                               title="{{ 'Reverse this sort key' if option.active else 'Add as a sort key' }}">
+                                {% if option.active %}<span class="sort-rank">{{ option.rank }}</span>{% endif %}
+                                {{ option.label }}
+                                {% if option.active %}<span class="sort-indicator">{{ '▲' if option.direction == 'asc' else '▼' }}</span>{% endif %}
+                            </a>
+                            {% if option.active and current_sort_by | length > 1 %}
+                                <a href="{{ url_for('list_articles', page=1, sort_by=option.remove_sort_by, direction=option.remove_direction, start_date=current_start_date, end_date=current_end_date, preset=current_preset, feed_profile=current_feed_profiles, search=current_search_term) }}"
+                                   class="sort-remove"
+                                   title="Remove this sort key"><i class="fas fa-times"></i></a>
+                            {% endif %}
+                        </span>
                     {% endfor %}
                 </div>
             </form>
@@ -121,14 +136,14 @@
             {% if total_pages > 1 %}
                 <div class="pagination">
                     {% if page > 1 %}
-                        <a href="{{ url_for('list_articles', page=page-1, sort_by=current_sort_by, direction=current_direction, start_date=current_start_date, end_date=current_end_date, preset=current_preset, feed_profile=current_feed_profile, search=current_search_term) }}"
+                        <a href="{{ url_for('list_articles', page=page-1, sort_by=current_sort_by, direction=current_direction, start_date=current_start_date, end_date=current_end_date, preset=current_preset, feed_profile=current_feed_profiles, search=current_search_term) }}"
                            class="page-link prev"><i class="fas fa-chevron-left"></i> Previous</a>
                     {% else %}
                         <span class="page-link disabled prev"><i class="fas fa-chevron-left"></i> Previous</span>
                     {% endif %}
                     <span class="page-info">Page {{ page }} of {{ total_pages }}</span>
                     {% if page < total_pages %}
-                        <a href="{{ url_for('list_articles', page=page+1, sort_by=current_sort_by, direction=current_direction, start_date=current_start_date, end_date=current_end_date, preset=current_preset, feed_profile=current_feed_profile, search=current_search_term) }}"
+                        <a href="{{ url_for('list_articles', page=page+1, sort_by=current_sort_by, direction=current_direction, start_date=current_start_date, end_date=current_end_date, preset=current_preset, feed_profile=current_feed_profiles, search=current_search_term) }}"
                            class="page-link next">Next <i class="fas fa-chevron-right"></i></a>
                     {% else %}
                         <span class="page-link disabled next">Next <i class="fas fa-chevron-right"></i></span>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -71,6 +71,66 @@ class TestArticlesRoute:
         response = client.get("/articles?start_date=2024-01-01&end_date=2024-01-31")
         assert response.status_code == 200
 
+    def test_articles_route_with_multiple_sort_keys(self, client):
+        """Test articles route accepts repeated sort_by/direction params."""
+        response = client.get("/articles?sort_by=impact_score&direction=desc&sort_by=published_date&direction=asc")
+        assert response.status_code == 200
+        # Both keys should be reflected in the sort controls links.
+        assert b"sort_by=impact_score&amp;sort_by=published_date" in response.data
+
+    def test_articles_route_sort_by_feed(self, client):
+        """Test articles route can sort by feed profile."""
+        response = client.get("/articles?sort_by=feed_profile&direction=asc")
+        assert response.status_code == 200
+
+
+class TestSortArgParsing:
+    """Tests for multi-key sort argument parsing."""
+
+    def test_parse_sort_args_defaults(self):
+        from meridiano.app import _parse_sort_args
+
+        assert _parse_sort_args([], []) == (["published_date"], ["desc"])
+
+    def test_parse_sort_args_pairs_directions_positionally(self):
+        from meridiano.app import _parse_sort_args
+
+        fields, directions = _parse_sort_args(["impact_score", "published_date"], ["desc", "asc"])
+        assert fields == ["impact_score", "published_date"]
+        assert directions == ["desc", "asc"]
+
+    def test_parse_sort_args_drops_unknown_and_duplicate_fields(self):
+        from meridiano.app import _parse_sort_args
+
+        fields, directions = _parse_sort_args(
+            ["impact_score", "bogus", "impact_score", "feed_profile"],
+            ["asc", "asc", "desc", "asc"],
+        )
+        assert fields == ["impact_score", "feed_profile"]
+        assert directions == ["asc", "asc"]
+
+    def test_parse_sort_args_defaults_missing_direction(self):
+        from meridiano.app import _parse_sort_args
+
+        fields, directions = _parse_sort_args(["impact_score", "published_date"], ["asc"])
+        assert directions == ["asc", "desc"]
+
+    def test_build_sort_options_toggles_and_appends(self):
+        from meridiano.app import _build_sort_options
+
+        options = {opt["field"]: opt for opt in _build_sort_options(["impact_score"], ["desc"])}
+
+        active = options["impact_score"]
+        assert active["active"] is True
+        assert active["rank"] == 1
+        assert active["toggle_direction"] == ["asc"]
+        assert active["remove_sort_by"] == []
+
+        inactive = options["published_date"]
+        assert inactive["active"] is False
+        assert inactive["toggle_sort_by"] == ["impact_score", "published_date"]
+        assert inactive["toggle_direction"] == ["desc", "desc"]
+
 
 class TestAddArticleRoute:
     """Tests for the add article route."""
@@ -213,7 +273,7 @@ class TestCollectionsRoutes:
         # Check we are back on the collections list page
         assert b"Collections" in response.data
         # Check for success flash message
-        assert b'Collection &#34;Ephemeral Collection&#34; has been deleted.' in response.data
+        assert b"Collection &#34;Ephemeral Collection&#34; has been deleted." in response.data
         # Check the link to the collection is no longer on the page.
         # We don't check for the name alone, as it appears in the flash message.
         assert f'<a href="/collection/{coll_id}"'.encode() not in response.data
@@ -248,7 +308,7 @@ class TestCollectionsRoutes:
         # Verify in DB
         with app.app_context():
             coll = get_collection_by_id(coll_id)
-            assert coll['archived'] is True
+            assert coll["archived"] is True
 
         # 3. Verify it shows up in "Archived Collections" section
         response = client.get("/collections")
@@ -263,7 +323,7 @@ class TestCollectionsRoutes:
         # Verify in DB
         with app.app_context():
             coll = get_collection_by_id(coll_id)
-            assert coll['archived'] is False
+            assert coll["archived"] is False
 
     def test_archive_nonexistent_collection(self, client):
         """Test attempting to archive a collection that doesn't exist."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -83,6 +83,20 @@ class TestArticlesRoute:
         response = client.get("/articles?sort_by=feed_profile&direction=asc")
         assert response.status_code == 200
 
+    def test_articles_route_single_sort_key_can_be_removed(self, client):
+        """The 'x' is offered even when a single sort key is active."""
+        response = client.get("/articles?sort_by=impact_score&direction=desc")
+        assert response.status_code == 200
+        assert b"sort-remove" in response.data
+        assert b"Clear the sort and go back to the default" in response.data
+
+    def test_articles_route_without_sort_falls_back_to_default(self, client):
+        """Clearing the last sort key lands on the default sort."""
+        response = client.get("/articles")
+        assert response.status_code == 200
+        # Published Date is active again, so its 'x' resets rather than removes.
+        assert b"Clear the sort and go back to the default" in response.data
+
 
 class TestSortArgParsing:
     """Tests for multi-key sort argument parsing."""
@@ -116,7 +130,7 @@ class TestSortArgParsing:
         assert directions == ["asc", "desc"]
 
     def test_build_sort_options_toggles_and_appends(self):
-        from meridiano.app import _build_sort_options
+        from meridiano.app import _build_sort_options, _parse_sort_args
 
         options = {opt["field"]: opt for opt in _build_sort_options(["impact_score"], ["desc"])}
 
@@ -124,7 +138,13 @@ class TestSortArgParsing:
         assert active["active"] is True
         assert active["rank"] == 1
         assert active["toggle_direction"] == ["asc"]
+        # Removing the only key leaves an empty chain, which parses back to the default.
         assert active["remove_sort_by"] == []
+        assert active["remove_direction"] == []
+        assert _parse_sort_args(active["remove_sort_by"], active["remove_direction"]) == (
+            ["published_date"],
+            ["desc"],
+        )
 
         inactive = options["published_date"]
         assert inactive["active"] is False

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -120,6 +120,66 @@ class TestGetAllArticles:
         assert len(articles) == 3
 
 
+class TestGetAllArticlesSorting:
+    """Tests for single and multi-key sorting of articles."""
+
+    @pytest.fixture
+    def scored_articles(self):
+        """Creates articles with known impact scores, dates and feed profiles."""
+        from datetime import datetime
+
+        from meridiano.models import Article
+
+        rows = [
+            ("older-high", 9, datetime(2024, 1, 1), "tech"),
+            ("newer-high", 9, datetime(2024, 3, 1), "brasil"),
+            ("newer-low", 2, datetime(2024, 4, 1), "tech"),
+        ]
+        with get_session() as session:
+            for title, score, published, profile in rows:
+                session.add(
+                    Article(
+                        url=f"https://example.com/{title}",
+                        title=title,
+                        published_date=published,
+                        feed_source="Test Feed",
+                        raw_content="content",
+                        feed_profile=profile,
+                        impact_score=score,
+                    )
+                )
+            session.commit()
+
+    def test_sort_by_single_key(self, scored_articles):
+        """A single sort key still works as before."""
+        titles = [a["title"] for a in get_all_articles(sort_by="published_date", direction="desc")]
+        assert titles == ["newer-low", "newer-high", "older-high"]
+
+    def test_sort_by_impact_then_date(self, scored_articles):
+        """Impact score first, published date breaking the tie."""
+        titles = [
+            a["title"] for a in get_all_articles(sort_by=["impact_score", "published_date"], direction=["desc", "asc"])
+        ]
+        assert titles == ["older-high", "newer-high", "newer-low"]
+
+    def test_sort_directions_are_independent_per_key(self, scored_articles):
+        """Flipping only the secondary direction reorders just the tied articles."""
+        titles = [
+            a["title"] for a in get_all_articles(sort_by=["impact_score", "published_date"], direction=["desc", "desc"])
+        ]
+        assert titles == ["newer-high", "older-high", "newer-low"]
+
+    def test_sort_by_feed_profile(self, scored_articles):
+        """Articles can be ordered by feed profile."""
+        profiles = [a["feed_profile"] for a in get_all_articles(sort_by="feed_profile", direction="asc")]
+        assert profiles == ["brasil", "tech", "tech"]
+
+    def test_unknown_sort_field_falls_back_to_published_date(self, scored_articles):
+        """An unknown sort field is ignored, leaving the default ordering."""
+        titles = [a["title"] for a in get_all_articles(sort_by="bogus_column", direction="desc")]
+        assert titles == ["newer-low", "newer-high", "older-high"]
+
+
 class TestFeedProfiles:
     """Tests for feed profile operations."""
 


### PR DESCRIPTION
Two related improvements to the articles page filters. Both are backwards compatible: existing single-value URLs and bookmarks behave exactly as before.

## Multi-select feed filter

The profile dropdown becomes a row of toggleable chips, so several profiles can be shown at once (e.g. `tech` + `brasil`) instead of one-or-all.

- `feed_profile` is read with `getlist`.
- `_build_article_filters` still accepts a plain string (unchanged behaviour) and now also accepts a list, which filters with `IN`.

## Multi-key sorting

`sort_by` and `direction` are now repeatable params, paired positionally:

```
/articles?sort_by=impact_score&direction=desc&sort_by=published_date&direction=asc
```

= impact score descending, published date ascending as the tie-breaker.

In the UI:

- clicking an inactive field **appends** it as the next tie-breaker;
- clicking an active field **flips** its direction, keeping its position;
- an `x` removes a key from the chain;
- a small numbered badge shows each key's precedence.

Also added **Feed** (`feed_profile`) and **Source** (`feed_source`) as sortable fields, which was the original itch — being able to group by source and then rank by impact.

Unknown or duplicated sort fields are ignored and fall back to the previous default (published date, descending). `Article.id` is still appended as the final ordering key so pagination stays stable.

## Testing

`make test` passes (12 new tests) and `make lint` is clean. New tests cover:

- `_parse_sort_args` / `_build_sort_options` (validation, dedupe, positional direction pairing, toggle/remove link state);
- the actual `ORDER BY` produced, including independent per-key directions and the unknown-field fallback;
- the `/articles` route with repeated params.

## Note

The stylesheet also gets `html[data-theme="dark"]` rules for the new chips and sort controls. They are inert unless my companion dark-mode PR is merged — I kept each widget's light and dark styling together rather than splitting it across the two PRs. Happy to drop them if you'd rather not carry them. Both PRs append to the end of `style.css`, so whichever lands second may need a trivial conflict resolution there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)