### PR TITLE
Articles & collections: choose how many items are shown per page

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Built for the curious mind wanting depth and relevance without the endless time 
 * **Impact Rating**: AI assigns a 1-10 impact score to articles based on their summary.
 * **Image Extraction**: Attempts to fetch representative images from RSS or article OG tags.
 * **FTS5 Search**: Fast and relevant full-text search across article titles and content.
-* **Web Interface**: Clean Flask-based UI to browse briefings and articles, with filtering (date, profile), sorting, pagination, and search.
+* **Web Interface**: Clean Flask-based UI to browse briefings and articles, with filtering (date, profile), sorting, pagination (selectable page size), and search.
 
 ## How It Works
 

--- a/src/meridiano/app.py
+++ b/src/meridiano/app.py
@@ -21,6 +21,30 @@ app.secret_key = os.getenv("FLASK_SECRET_KEY", "a_default_secret_key_for_develop
 app.jinja_env.filters["datetimeformat"] = format_datetime
 
 
+# Page sizes offered in the articles list dropdown.
+ARTICLES_PER_PAGE_CHOICES = (10, 15, 25, 50, 100)
+
+
+def _parse_per_page(per_page_arg):
+    """
+    Returns the page size to use, the choices to offer in the dropdown, and the
+    value links should carry.
+
+    The configured default is always part of the choices, even when it is not one
+    of the presets, and anything outside them falls back to that default. Links
+    only carry the page size when it differs from the default, keeping URLs tidy.
+    """
+    default = getattr(config, "ARTICLES_PER_PAGE", 25)
+    options = sorted({*ARTICLES_PER_PAGE_CHOICES, default})
+    try:
+        per_page = int(per_page_arg)
+    except (TypeError, ValueError):
+        per_page = default
+    if per_page not in options:
+        per_page = default
+    return per_page, options, (per_page if per_page != default else None)
+
+
 def process_artciles_content(articles_data):
     return [
         {
@@ -79,7 +103,7 @@ def list_articles():
     except ValueError:
         page = 1
     page = max(1, page)
-    per_page = getattr(config, "ARTICLES_PER_PAGE", 25)
+    per_page, per_page_options, per_page_param = _parse_per_page(request.args.get("per_page"))
 
     # --- Sorting ---
     sort_by = request.args.get("sort_by", "published_date")
@@ -183,6 +207,8 @@ def list_articles():
         page=page,
         total_pages=total_pages,
         per_page=per_page,
+        per_page_options=per_page_options,
+        per_page_param=per_page_param,
         total_articles=total_articles,  # Filtered total
         current_sort_by=sort_by,
         current_direction=direction,

--- a/src/meridiano/app.py
+++ b/src/meridiano/app.py
@@ -399,9 +399,32 @@ def view_collection(collection_id):
     coll = database.get_collection_by_id(collection_id)
     if coll is None:
         abort(404)
-    articles = database.get_articles_for_collection(collection_id)
+
+    try:
+        page = int(request.args.get("page", 1))
+    except ValueError:
+        page = 1
+    page = max(1, page)
+    per_page, per_page_options, per_page_param = _parse_per_page(request.args.get("per_page"))
+
+    total_articles = database.get_article_count_for_collection(collection_id)
+    total_pages = math.ceil(total_articles / per_page) if total_articles > 0 else 0
+    if total_pages > 0 and page > total_pages:
+        page = total_pages
+
+    articles = database.get_articles_for_collection(collection_id, page=page, per_page=per_page)
     articles = process_artciles_content(articles)
-    return render_template("collection_detail.html", collection=coll, articles=articles)
+    return render_template(
+        "collection_detail.html",
+        collection=coll,
+        articles=articles,
+        page=page,
+        total_pages=total_pages,
+        per_page=per_page,
+        per_page_options=per_page_options,
+        per_page_param=per_page_param,
+        total_articles=total_articles,
+    )
 
 
 @app.route("/collection/<int:collection_id>/delete", methods=["POST"])

--- a/src/meridiano/database.py
+++ b/src/meridiano/database.py
@@ -500,8 +500,15 @@ def remove_article_from_collection(collection_id: int, article_id: int) -> None:
             session.commit()
 
 
-def get_articles_for_collection(collection_id: int) -> List[Dict[str, Any]]:
-    """Return article dicts for all articles in a collection ordered by fetched_at desc."""
+def get_articles_for_collection(
+    collection_id: int, page: Optional[int] = None, per_page: Optional[int] = None
+) -> List[Dict[str, Any]]:
+    """
+    Return article dicts for a collection ordered by fetched_at desc.
+
+    Passing both page and per_page returns only that page; leaving them out
+    returns every article in the collection.
+    """
     with get_session() as session:
         stmt = (
             select(Article)
@@ -509,6 +516,8 @@ def get_articles_for_collection(collection_id: int) -> List[Dict[str, Any]]:
             .where(CollectionArticle.collection_id == collection_id)
             .order_by(desc(Article.fetched_at))
         )
+        if page is not None and per_page is not None:
+            stmt = stmt.offset((max(1, page) - 1) * per_page).limit(per_page)
         articles = session.exec(stmt).all()
         return [_article_to_dict(article) for article in articles]
 

--- a/src/meridiano/static/css/style.css
+++ b/src/meridiano/static/css/style.css
@@ -725,6 +725,34 @@ blockquote {
     color: #343a40; /* Dark color for indicator */
 }
 
+/* Page size selector, sitting at the right end of the list it belongs to */
+.per-page-control {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.9em;
+    color: #6c757d;
+}
+
+.sort-controls .per-page-control {
+    float: right;
+    font-size: 1em;
+}
+
+.per-page-control label {
+    color: #495057;
+}
+
+.per-page-control select {
+    padding: 3px 6px;
+    border: 1px solid #ced4da;
+    border-radius: 4px;
+    background-color: #fff;
+    color: #495057;
+    font-size: 1em;
+    cursor: pointer;
+}
+
 /* --- Feed Profile Filter & Badge Styling --- */
 .profile-filter {
     margin-bottom: 15px;
@@ -1127,12 +1155,14 @@ html[data-theme="dark"] .search-filter {
 html[data-theme="dark"] .form-control,
 html[data-theme="dark"] .theme-select,
 html[data-theme="dark"] .date-inputs input[type="date"],
-html[data-theme="dark"] .profile-filter.form-section select {
+html[data-theme="dark"] .profile-filter.form-section select,
+html[data-theme="dark"] .per-page-control select {
     background-color: #2b2f36;
     color: #e4e6eb;
     border-color: #495057;
 }
 html[data-theme="dark"] .search-filter input[type="search"] { color: #e4e6eb; }
+html[data-theme="dark"] .per-page-control label { color: #9aa0a6; }
 
 html[data-theme="dark"] .article-details dd { border-left-color: #343a40; }
 html[data-theme="dark"] .article-image-container { background-color: #2b2f36; }

--- a/src/meridiano/static/css/style.css
+++ b/src/meridiano/static/css/style.css
@@ -753,6 +753,28 @@ blockquote {
     cursor: pointer;
 }
 
+/* Header row pairing a list heading with its page size selector */
+.list-controls {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 15px;
+    flex-wrap: wrap;
+}
+
+.list-controls h3 {
+    margin: 0;
+}
+
+.per-page-form {
+    margin: 0;
+}
+
+.list-summary {
+    color: #6c757d;
+    font-size: 0.9em;
+}
+
 /* --- Feed Profile Filter & Badge Styling --- */
 .profile-filter {
     margin-bottom: 15px;
@@ -1162,7 +1184,9 @@ html[data-theme="dark"] .per-page-control select {
     border-color: #495057;
 }
 html[data-theme="dark"] .search-filter input[type="search"] { color: #e4e6eb; }
-html[data-theme="dark"] .per-page-control label { color: #9aa0a6; }
+html[data-theme="dark"] .per-page-control,
+html[data-theme="dark"] .per-page-control label,
+html[data-theme="dark"] .list-summary { color: #9aa0a6; }
 
 html[data-theme="dark"] .article-details dd { border-left-color: #343a40; }
 html[data-theme="dark"] .article-image-container { background-color: #2b2f36; }

--- a/src/meridiano/templates/articles.html
+++ b/src/meridiano/templates/articles.html
@@ -55,7 +55,7 @@
                             <i class="fas fa-search"></i>
                         </button>
                         {% if current_search_term %}
-                            <a href="{{ url_for('list_articles', page=1, sort_by=current_sort_by, direction=current_direction, start_date=current_start_date, end_date=current_end_date, preset=current_preset, feed_profile=current_feed_profile) }}"
+                            <a href="{{ url_for('list_articles', page=1, sort_by=current_sort_by, direction=current_direction, start_date=current_start_date, end_date=current_end_date, preset=current_preset, feed_profile=current_feed_profile, per_page=per_page_param) }}"
                                class="btn btn-clear-search"
                                title="Clear Search"><i class="fas fa-times"></i></a>
                         {% endif %}
@@ -82,7 +82,7 @@
                                    name="end_date"
                                    value="{{ current_end_date }}">
                             <button type="submit" class="btn btn-filter"><i class="fas fa-filter"></i> Apply Filters</button>
-                            <a href="{{ url_for('list_articles', sort_by=current_sort_by, direction=current_direction, feed_profile=current_feed_profile, search=current_search_term) }}"
+                            <a href="{{ url_for('list_articles', sort_by=current_sort_by, direction=current_direction, feed_profile=current_feed_profile, search=current_search_term, per_page=per_page_param) }}"
                                class="btn btn-clear"><i class="fas fa-times-circle"></i> Clear Dates</a>
                         </div>
                         <div class="preset-buttons">
@@ -94,19 +94,27 @@
                                 "last_12m": "Last 12mo"
                             } %}
                             {% for key, label in presets.items() %}
-                                <a href="{{ url_for('list_articles', preset=key, sort_by=current_sort_by, direction=current_direction, feed_profile=current_feed_profile, search=current_search_term) }}"
+                                <a href="{{ url_for('list_articles', preset=key, sort_by=current_sort_by, direction=current_direction, feed_profile=current_feed_profile, search=current_search_term, per_page=per_page_param) }}"
                                    class="btn btn-preset {{ 'active' if current_preset == key else '' }}">{{ label }}</a>
                             {% endfor %}
                         </div>
                     </div>
                 </div>
                 <div class="sort-controls form-section">
+                    <span class="per-page-control">
+                        <label for="per_page">Per page:</label>
+                        <select name="per_page" id="per_page" onchange="this.form.submit()">
+                            {% for option in per_page_options %}
+                                <option value="{{ option }}" {% if option == per_page %}selected{% endif %}>{{ option }}</option>
+                            {% endfor %}
+                        </select>
+                    </span>
                     Sort by:
                     {% set sort_fields = {"published_date": "Published Date", "impact_score": "Impact Score"} %}
                     {% for field, label in sort_fields.items() %}
                         {% set is_active = (current_sort_by == field) %}
                         {% set next_direction = 'asc' if (is_active and current_direction == 'desc') else 'desc' %}
-                        <a href="{{ url_for('list_articles', page=1, sort_by=field, direction=next_direction, start_date=current_start_date, end_date=current_end_date, preset=current_preset, feed_profile=current_feed_profile, search=current_search_term) }}"
+                        <a href="{{ url_for('list_articles', page=1, sort_by=field, direction=next_direction, start_date=current_start_date, end_date=current_end_date, preset=current_preset, feed_profile=current_feed_profile, search=current_search_term, per_page=per_page_param) }}"
                            class="sort-link {{ 'active' if is_active else '' }}">{{ label }}
                             {% if is_active %}<span class="sort-indicator">{{ '▲' if current_direction == 'asc' else '▼' }}</span>{% endif %}
                         </a>
@@ -121,14 +129,14 @@
             {% if total_pages > 1 %}
                 <div class="pagination">
                     {% if page > 1 %}
-                        <a href="{{ url_for('list_articles', page=page-1, sort_by=current_sort_by, direction=current_direction, start_date=current_start_date, end_date=current_end_date, preset=current_preset, feed_profile=current_feed_profile, search=current_search_term) }}"
+                        <a href="{{ url_for('list_articles', page=page-1, sort_by=current_sort_by, direction=current_direction, start_date=current_start_date, end_date=current_end_date, preset=current_preset, feed_profile=current_feed_profile, search=current_search_term, per_page=per_page_param) }}"
                            class="page-link prev"><i class="fas fa-chevron-left"></i> Previous</a>
                     {% else %}
                         <span class="page-link disabled prev"><i class="fas fa-chevron-left"></i> Previous</span>
                     {% endif %}
                     <span class="page-info">Page {{ page }} of {{ total_pages }}</span>
                     {% if page < total_pages %}
-                        <a href="{{ url_for('list_articles', page=page+1, sort_by=current_sort_by, direction=current_direction, start_date=current_start_date, end_date=current_end_date, preset=current_preset, feed_profile=current_feed_profile, search=current_search_term) }}"
+                        <a href="{{ url_for('list_articles', page=page+1, sort_by=current_sort_by, direction=current_direction, start_date=current_start_date, end_date=current_end_date, preset=current_preset, feed_profile=current_feed_profile, search=current_search_term, per_page=per_page_param) }}"
                            class="page-link next">Next <i class="fas fa-chevron-right"></i></a>
                     {% else %}
                         <span class="page-link disabled next">Next <i class="fas fa-chevron-right"></i></span>

--- a/src/meridiano/templates/collection_detail.html
+++ b/src/meridiano/templates/collection_detail.html
@@ -31,13 +31,49 @@
 
         <hr>
 
-        <h3>Articles in this collection</h3>
+        <div class="list-controls">
+            <h3>Articles in this collection</h3>
+            {% if total_articles > 0 %}
+                <form method="GET" action="{{ url_for('view_collection', collection_id=collection['id']) }}" class="per-page-form">
+                    <span class="per-page-control">
+                        <label for="per_page">Per page:</label>
+                        <select name="per_page" id="per_page" onchange="this.form.submit()">
+                            {% for option in per_page_options %}
+                                <option value="{{ option }}" {% if option == per_page %}selected{% endif %}>{{ option }}</option>
+                            {% endfor %}
+                        </select>
+                    </span>
+                </form>
+            {% endif %}
+        </div>
+        {% if total_articles > 0 %}
+            <p class="list-summary">
+                Showing articles {{ (page - 1) * per_page + 1 }} - {{ [page * per_page, total_articles] | min }} of {{ total_articles }} total.
+            </p>
+        {% endif %}
         <ul class="article-list">
             {% for article in articles %}
                 {% include '_article_item.html' %}
             {% endfor %}
         </ul>
         <p id="no-articles-message" {% if articles %}style="display: none;"{% endif %}>No articles in this collection yet.</p>
+        {% if total_pages > 1 %}
+            <div class="pagination">
+                {% if page > 1 %}
+                    <a href="{{ url_for('view_collection', collection_id=collection['id'], page=page-1, per_page=per_page_param) }}"
+                       class="page-link prev"><i class="fas fa-chevron-left"></i> Previous</a>
+                {% else %}
+                    <span class="page-link disabled prev"><i class="fas fa-chevron-left"></i> Previous</span>
+                {% endif %}
+                <span class="page-info">Page {{ page }} of {{ total_pages }}</span>
+                {% if page < total_pages %}
+                    <a href="{{ url_for('view_collection', collection_id=collection['id'], page=page+1, per_page=per_page_param) }}"
+                       class="page-link next">Next <i class="fas fa-chevron-right"></i></a>
+                {% else %}
+                    <span class="page-link disabled next">Next <i class="fas fa-chevron-right"></i></span>
+                {% endif %}
+            </div>
+        {% endif %}
 
     </div>
 </body>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../s
 # Import app after setting up test database
 os.environ["DATABASE_URL"] = "sqlite:///:memory:"
 from meridiano.app import app
-from meridiano.database import add_article, create_collection, get_collection_by_id
+from meridiano.database import add_article, add_article_to_collection, create_collection, get_collection_by_id
 
 
 @pytest.fixture
@@ -254,6 +254,58 @@ class TestCollectionsRoutes:
         assert response.status_code == 200
         assert b"Collection name is required." in response.data
         assert b"Collections" in response.data  # Should be back on the collections list page
+
+    def test_view_collection_paginates_articles(self, client, sample_article_data):
+        """A collection larger than the page size is split into pages."""
+        with app.app_context():
+            coll_id = create_collection("Big Collection")
+            for index in range(12):
+                article_id = add_article(**{**sample_article_data, "url": f"https://example.com/a{index}"})
+                add_article_to_collection(coll_id, article_id)
+
+        response = client.get(f"/collection/{coll_id}?per_page=10")
+        assert response.status_code == 200
+        assert b"Showing articles 1 - 10 of 12 total." in response.data
+        assert b"Page 1 of 2" in response.data
+        assert f"/collection/{coll_id}?page=2&amp;per_page=10".encode() in response.data
+
+        response = client.get(f"/collection/{coll_id}?page=2&per_page=10")
+        assert response.status_code == 200
+        assert b"Showing articles 11 - 12 of 12 total." in response.data
+
+    def test_view_collection_shows_per_page_dropdown(self, client, sample_article_data):
+        """The collection page offers the same page size selector as the articles list."""
+        with app.app_context():
+            coll_id = create_collection("Collection With Articles")
+            article_id = add_article(**sample_article_data)
+            add_article_to_collection(coll_id, article_id)
+
+        response = client.get(f"/collection/{coll_id}?per_page=50")
+        assert response.status_code == 200
+        assert b'name="per_page"' in response.data
+        assert b'<option value="50" selected' in response.data
+
+    def test_view_collection_rejects_unknown_per_page(self, client, sample_article_data):
+        """Page sizes outside the offered choices fall back to the default."""
+        with app.app_context():
+            coll_id = create_collection("Collection Default Size")
+            article_id = add_article(**sample_article_data)
+            add_article_to_collection(coll_id, article_id)
+
+        response = client.get(f"/collection/{coll_id}?per_page=999")
+        assert response.status_code == 200
+        assert b'value="999"' not in response.data
+        assert b'<option value="15" selected' in response.data
+
+    def test_view_empty_collection_hides_pagination_controls(self, client):
+        """An empty collection shows neither the selector nor a summary line."""
+        with app.app_context():
+            coll_id = create_collection("Empty Collection")
+
+        response = client.get(f"/collection/{coll_id}")
+        assert response.status_code == 200
+        assert b'name="per_page"' not in response.data
+        assert b"No articles in this collection yet." in response.data
 
     def test_view_collection_not_found(self, client):
         """Test viewing a non-existent collection."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -61,6 +61,33 @@ class TestArticlesRoute:
         response = client.get("/articles?page=1")
         assert response.status_code == 200
 
+    def test_articles_route_shows_per_page_dropdown(self, client):
+        """The articles list offers a page size selector."""
+        response = client.get("/articles")
+        assert response.status_code == 200
+        assert b'name="per_page"' in response.data
+        assert b'<option value="50"' in response.data
+
+    def test_articles_route_honours_per_page(self, client):
+        """A valid per_page choice is applied and kept in the page links."""
+        response = client.get("/articles?per_page=50")
+        assert response.status_code == 200
+        assert b'<option value="50" selected' in response.data
+        assert b"per_page=50" in response.data
+
+    def test_articles_route_rejects_unknown_per_page(self, client):
+        """Values outside the offered choices fall back to the default."""
+        response = client.get("/articles?per_page=999")
+        assert response.status_code == 200
+        assert b'value="999"' not in response.data
+        assert b'<option value="15" selected' in response.data
+
+    def test_articles_route_ignores_non_numeric_per_page(self, client):
+        """A non-numeric per_page does not break the page."""
+        response = client.get("/articles?per_page=abc")
+        assert response.status_code == 200
+        assert b'<option value="15" selected' in response.data
+
     def test_articles_route_with_search(self, client):
         """Test articles route with search term."""
         response = client.get("/articles?search=test")
@@ -70,6 +97,47 @@ class TestArticlesRoute:
         """Test articles route with date filters."""
         response = client.get("/articles?start_date=2024-01-01&end_date=2024-01-31")
         assert response.status_code == 200
+
+
+class TestPerPageParsing:
+    """Tests for the articles page size argument."""
+
+    def test_parse_per_page_defaults(self):
+        from meridiano.app import _parse_per_page
+
+        per_page, options, per_page_param = _parse_per_page(None)
+        assert per_page == 15
+        assert per_page in options
+        # The default is implicit, so links do not need to carry it.
+        assert per_page_param is None
+
+    def test_parse_per_page_accepts_offered_choice(self):
+        from meridiano.app import _parse_per_page
+
+        assert _parse_per_page("100")[0] == 100
+        # A non-default size has to travel with the links.
+        assert _parse_per_page("100")[2] == 100
+
+    def test_parse_per_page_rejects_values_outside_the_choices(self):
+        from meridiano.app import _parse_per_page
+
+        assert _parse_per_page("7")[0] == 15
+        assert _parse_per_page("-10")[0] == 15
+        assert _parse_per_page("abc")[0] == 15
+
+    def test_parse_per_page_always_offers_the_configured_default(self):
+        from meridiano import app as app_module
+        from meridiano.app import _parse_per_page
+
+        original = app_module.config.ARTICLES_PER_PAGE
+        app_module.config.ARTICLES_PER_PAGE = 42
+        try:
+            per_page, options, _ = _parse_per_page(None)
+            assert per_page == 42
+            assert 42 in options
+            assert _parse_per_page("42")[0] == 42
+        finally:
+            app_module.config.ARTICLES_PER_PAGE = original
 
 
 class TestAddArticleRoute:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -333,6 +333,27 @@ class TestCollections:
         retrieved_ids = {a["id"] for a in articles}
         assert retrieved_ids == set(article_ids)
 
+    def test_get_articles_for_collection_pagination(self, sample_article_data):
+        """page/per_page slice the collection, and omitting them returns everything."""
+        coll_id = create_collection("Paged Collection")
+        for i in range(5):
+            data = sample_article_data.copy()
+            data["url"] = f"http://example.com/paged/{i}"
+            add_article_to_collection(coll_id, add_article(**data))
+
+        all_articles = get_articles_for_collection(coll_id)
+        assert len(all_articles) == 5
+
+        first_page = get_articles_for_collection(coll_id, page=1, per_page=2)
+        second_page = get_articles_for_collection(coll_id, page=2, per_page=2)
+        last_page = get_articles_for_collection(coll_id, page=3, per_page=2)
+        assert [a["id"] for a in first_page] == [a["id"] for a in all_articles[:2]]
+        assert [a["id"] for a in second_page] == [a["id"] for a in all_articles[2:4]]
+        assert [a["id"] for a in last_page] == [a["id"] for a in all_articles[4:]]
+
+        # Past the end there is simply nothing left.
+        assert get_articles_for_collection(coll_id, page=99, per_page=2) == []
+
     def test_delete_collection(self, sample_article_data):
         """Test deleting a collection and its associations, but not the articles."""
         # 1. Setup: Create an article and a collection


### PR DESCRIPTION
## What

Adds a **Per page** dropdown to the articles list and to the collection detail page, so the number of items shown is a user choice instead of being fixed by `ARTICLES_PER_PAGE`.

Choices are 10 / 15 / 25 / 50 / 100, plus the configured `ARTICLES_PER_PAGE` value when it is not one of those presets — so an instance with, say, `ARTICLES_PER_PAGE = 40` still sees its own default in the list.

## Details

- `_parse_per_page()` in `app.py` is shared by both views. Anything outside the offered choices (unknown number, negative, non-numeric) falls back to the configured default.
- Links only carry `per_page` when it differs from the default, so existing URLs are unchanged for anyone who does not touch the dropdown.
- Changing the page size submits the filter form, which drops `page` and lands the user back on page 1.
- Opening a collection previously rendered **every** article it contained in a single page. The collection detail view is now paginated with prev/next controls and a "Showing articles X - Y of N" line, matching the articles list. `get_articles_for_collection()` gained optional `page`/`per_page` arguments and still returns the whole collection when they are omitted, so the existing membership lookups are unaffected.
- Styling follows the existing controls and includes the dark theme.

## Tests

`pytest` — 74 passed. New coverage: page size parsing (defaults, offered choices, rejected values, custom configured default), the dropdown rendering on both pages, and collection pagination at both the route and database level.