### PR TITLE
Briefings: lista de fontes ordenada por impact score

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,11 @@ TOGETHER_AI_API_KEY=your_together_ai_api_key_here
 LLM_CHAT_MODEL=deepseek/deepseek-chat
 EMBEDDING_MODEL=together_ai/intfloat/multilingual-e5-large-instruct
 
+# Completion budget per chat call. Reasoning models spend this on reasoning tokens
+# before writing any answer, so too low a value yields empty briefs. Raise it if you
+# see "LLM spent its entire completion budget reasoning" in the logs.
+LLM_MAX_TOKENS=16384
+
 # For use with ollama
 OLLAMA_API_BASE=http://localhost:11434
 # LLM_CHAT_MODEL=ollama/qwen3:30b

--- a/src/meridiano/app.py
+++ b/src/meridiano/app.py
@@ -33,30 +33,6 @@ def process_artciles_content(articles_data):
     ]
 
 
-def _group_sources(links, articles_by_id):
-    """Groups a brief's source articles by cluster, preserving link order.
-
-    Falls back to a single untitled group when the brief has no link rows, which
-    is the case for briefs generated before source tracking existed.
-    """
-    if not links:
-        return [{"topic": None, "articles": list(articles_by_id.values())}] if articles_by_id else []
-
-    groups = []
-    by_index = {}
-    for link in links:
-        article = articles_by_id.get(link["article_id"])
-        if not article:
-            continue
-        index = link["cluster_index"]
-        if index not in by_index:
-            by_index[index] = {"topic": link["cluster_topic"], "articles": []}
-            groups.append(by_index[index])
-        by_index[index]["articles"].append(article)
-
-    return [group for group in groups if group["articles"]]
-
-
 @app.route("/")
 def index():
     """Displays a list of briefings, filterable by feed profile."""
@@ -85,7 +61,6 @@ def view_brief(brief_id):
 
     links = database.get_brief_article_links(brief_id)
     if links:
-        # Already ordered by cluster, then by impact score within each cluster.
         source_ids = [link["article_id"] for link in links]
     else:
         # Briefs generated before source tracking existed only have the JSON id list.
@@ -95,14 +70,13 @@ def view_brief(brief_id):
             source_ids = []
 
     sources = database.get_articles_by_ids(source_ids)
-    if not links:
-        # No clusters to group by, so rank the whole list. Unscored articles sort last.
-        sources.sort(key=lambda a: (a["impact_score"] is None, -(a["impact_score"] or 0)))
+    # One flat list ranked by impact, ignoring which cluster an article came from.
+    # Unscored articles sort last.
+    sources.sort(key=lambda a: (a["impact_score"] is None, -(a["impact_score"] or 0)))
 
     # Count what actually exists, so the cap label never promises a deleted article.
     source_total = len(sources)
     source_articles = process_artciles_content(sources[: config.BRIEF_MAX_SOURCES])
-    articles_by_id = {article["id"]: article for article in source_articles}
 
     brief_content_html = Markup(markdown.markdown(brief_data["brief_markdown"], extensions=["fenced_code"]))
     generation_time = format_datetime(brief_data["generated_at"], "%Y-%m-%d %H:%M:%S UTC")
@@ -112,10 +86,9 @@ def view_brief(brief_id):
         brief_id=brief_data["id"],
         brief_content=brief_content_html,
         generation_time=generation_time,
-        source_groups=_group_sources(links, articles_by_id),
+        source_articles=source_articles,
         source_count=len(source_articles),
         source_total=source_total,
-        sources_grouped=bool(links),
     )
 
 

--- a/src/meridiano/app.py
+++ b/src/meridiano/app.py
@@ -33,6 +33,30 @@ def process_artciles_content(articles_data):
     ]
 
 
+def _group_sources(links, articles_by_id):
+    """Groups a brief's source articles by cluster, preserving link order.
+
+    Falls back to a single untitled group when the brief has no link rows, which
+    is the case for briefs generated before source tracking existed.
+    """
+    if not links:
+        return [{"topic": None, "articles": list(articles_by_id.values())}] if articles_by_id else []
+
+    groups = []
+    by_index = {}
+    for link in links:
+        article = articles_by_id.get(link["article_id"])
+        if not article:
+            continue
+        index = link["cluster_index"]
+        if index not in by_index:
+            by_index[index] = {"topic": link["cluster_topic"], "articles": []}
+            groups.append(by_index[index])
+        by_index[index]["articles"].append(article)
+
+    return [group for group in groups if group["articles"]]
+
+
 @app.route("/")
 def index():
     """Displays a list of briefings, filterable by feed profile."""
@@ -59,6 +83,27 @@ def view_brief(brief_id):
     if brief_data is None:
         abort(404)  # Return a 404 error if brief not found
 
+    links = database.get_brief_article_links(brief_id)
+    if links:
+        # Already ordered by cluster, then by impact score within each cluster.
+        source_ids = [link["article_id"] for link in links]
+    else:
+        # Briefs generated before source tracking existed only have the JSON id list.
+        try:
+            source_ids = json.loads(brief_data["contributing_article_ids"] or "[]")
+        except (TypeError, ValueError):
+            source_ids = []
+
+    sources = database.get_articles_by_ids(source_ids)
+    if not links:
+        # No clusters to group by, so rank the whole list. Unscored articles sort last.
+        sources.sort(key=lambda a: (a["impact_score"] is None, -(a["impact_score"] or 0)))
+
+    # Count what actually exists, so the cap label never promises a deleted article.
+    source_total = len(sources)
+    source_articles = process_artciles_content(sources[: config.BRIEF_MAX_SOURCES])
+    articles_by_id = {article["id"]: article for article in source_articles}
+
     brief_content_html = Markup(markdown.markdown(brief_data["brief_markdown"], extensions=["fenced_code"]))
     generation_time = format_datetime(brief_data["generated_at"], "%Y-%m-%d %H:%M:%S UTC")
 
@@ -67,6 +112,10 @@ def view_brief(brief_id):
         brief_id=brief_data["id"],
         brief_content=brief_content_html,
         generation_time=generation_time,
+        source_groups=_group_sources(links, articles_by_id),
+        source_count=len(source_articles),
+        source_total=source_total,
+        sources_grouped=bool(links),
     )
 
 

--- a/src/meridiano/config_base.py
+++ b/src/meridiano/config_base.py
@@ -58,6 +58,19 @@ Analyzed News Clusters (Most significant first):
 {cluster_analyses_text}
 """
 
+# Appended to the cluster analysis prompt (see run_briefing.generate_brief).
+# Kept outside PROMPT_CLUSTER_ANALYSIS so it still applies to the feed profiles
+# that override that template. The TOPIC line is stripped back off before the
+# analysis is used, so it only ever surfaces as a heading in the source list.
+PROMPT_CLUSTER_TOPIC_RULE = """
+Begin your response with a single line `TOPIC: <a 3-6 word title for this story>` followed by a blank line.
+"""
+
+# Cap on the source articles listed under a brief. Briefs generated before source
+# tracking existed fall back to contributing_article_ids, which can hold hundreds
+# of articles and makes the page enormous.
+BRIEF_MAX_SOURCES = 60
+
 # --- Processing Settings ---
 # How many hours back to look for articles when generating a brief
 BRIEFING_ARTICLE_LOOKBACK_HOURS = 24
@@ -67,6 +80,12 @@ BRIEFING_ARTICLE_LOOKBACK_HOURS = 24
 LLM_CHAT_MODEL = os.getenv("LLM_CHAT_MODEL", "deepseek/deepseek-chat")
 # Model for embeddings
 EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "together_ai/intfloat/multilingual-e5-large-instruct")
+
+# Completion budget per chat call. Reasoning models (deepseek-v4-flash and friends)
+# spend this budget on reasoning tokens *before* writing any answer, so a cap that is
+# merely small comes back as an empty string with finish_reason="length" rather than
+# as an error. The brief synthesis prompt is the longest one and needs the most room.
+LLM_MAX_TOKENS = int(os.getenv("LLM_MAX_TOKENS", "16384"))
 
 # Approximate number of clusters to aim for. Fine-tune based on results.
 # Alternatively, use algorithms like DBSCAN that don't require specifying k.

--- a/src/meridiano/database.py
+++ b/src/meridiano/database.py
@@ -8,12 +8,12 @@ import logging
 from datetime import date, datetime, timedelta
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import text
+from sqlalchemy import nullslast, text
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import and_, asc, desc, func, or_, select
 
 from . import config_base as config
-from .models import Article, Brief, Collection, CollectionArticle, get_session
+from .models import Article, Brief, BriefArticle, Collection, CollectionArticle, get_session
 from .models import init_db as model_init_db
 
 logger = logging.getLogger(__name__)
@@ -71,6 +71,29 @@ def get_article_by_id(article_id: int) -> Optional[Dict[str, Any]]:
         statement = select(Article).where(Article.id == article_id)
         article = session.exec(statement).first()
         return _article_to_dict(article) if article else None
+
+
+def get_articles_by_ids(article_ids: List[int]) -> List[Dict[str, Any]]:
+    """Retrieves several articles in one query, in the order the ids were given.
+
+    Duplicate ids yield a single row. Ids with no matching row are skipped
+    silently, so callers can pass stale ids (e.g. from an old brief) without
+    special-casing deleted articles.
+    """
+    if not article_ids:
+        return []
+
+    with get_session() as session:
+        statement = select(Article).where(Article.id.in_(article_ids))
+        found = {article.id: article for article in session.exec(statement).all()}
+
+    ordered = []
+    seen = set()
+    for aid in article_ids:
+        if aid in found and aid not in seen:
+            seen.add(aid)
+            ordered.append(_article_to_dict(found[aid]))
+    return ordered
 
 
 def _article_to_dict(article: Article) -> Dict[str, Any]:
@@ -336,8 +359,18 @@ def get_articles_for_briefing(lookback_hours: int, feed_profile: str) -> List[Di
         return [_article_to_dict(article) for article in articles]
 
 
-def save_brief(brief_markdown: str, contributing_article_ids: List[int], feed_profile: str) -> int:
-    """Saves the generated brief including its feed profile."""
+def save_brief(
+    brief_markdown: str,
+    contributing_article_ids: List[int],
+    feed_profile: str,
+    article_links: Optional[List[Dict[str, Any]]] = None,
+) -> int:
+    """Saves the generated brief including its feed profile.
+
+    ``article_links`` optionally records which articles the brief was built from,
+    as dicts with ``article_id``, ``cluster_index`` and ``cluster_topic`` keys.
+    They are written to ``BriefArticle`` in the same transaction.
+    """
     with get_session() as session:
         ids_json = json.dumps(contributing_article_ids)
         brief = Brief(
@@ -363,8 +396,48 @@ def save_brief(brief_markdown: str, contributing_article_ids: List[int], feed_pr
         session.add(brief)
         session.commit()
         session.refresh(brief)  # Get the ID
+
+        if article_links:
+            for link in article_links:
+                session.add(
+                    BriefArticle(
+                        brief_id=brief.id,
+                        article_id=link["article_id"],
+                        cluster_index=link.get("cluster_index"),
+                        cluster_topic=link.get("cluster_topic"),
+                    )
+                )
+            session.commit()
+
         print(f"Saved brief [{feed_profile}] with ID: {brief.id}")
         return brief.id
+
+
+def get_brief_article_links(brief_id: int) -> List[Dict[str, Any]]:
+    """Retrieves the article links recorded for a brief, grouped by cluster.
+
+    Clusters keep the order the brief synthesized them in; within a cluster the
+    articles are ranked by impact score, highest first. Unscored articles sort
+    last rather than ahead of everything, which is what a NULL would otherwise do
+    under DESC on some backends.
+
+    Links whose article has since been deleted are dropped by the join, since a
+    source that cannot be rendered is not worth reporting.
+    """
+    with get_session() as session:
+        statement = (
+            select(BriefArticle)
+            .join(Article, Article.id == BriefArticle.article_id)
+            .where(BriefArticle.brief_id == brief_id)
+            .order_by(
+                asc(BriefArticle.cluster_index),
+                nullslast(desc(Article.impact_score)),
+                asc(BriefArticle.article_id),
+            )
+        )
+        links = session.exec(statement).all()
+
+        return [link.model_dump(include={"brief_id", "article_id", "cluster_index", "cluster_topic"}) for link in links]
 
 
 def get_all_briefs_metadata(

--- a/src/meridiano/models.py
+++ b/src/meridiano/models.py
@@ -78,6 +78,21 @@ class Brief(SQLModel, table=True):
     feed_profile: str = Field(default="default", index=True)
 
 
+class BriefArticle(SQLModel, table=True):
+    """Association between a brief and the articles it was built from.
+
+    Only the articles actually shown to the LLM are recorded, so the source list
+    under a brief never claims an article the analysis never saw. ``cluster_index``
+    keeps them in the order the clusters were synthesized; ``cluster_topic`` is the
+    heading the model gave that cluster, and is None when it ignored the request.
+    """
+
+    brief_id: Optional[int] = Field(default=None, foreign_key="briefs.id", primary_key=True)
+    article_id: Optional[int] = Field(default=None, foreign_key="articles.id", primary_key=True)
+    cluster_index: Optional[int] = None
+    cluster_topic: Optional[str] = None
+
+
 # Collections models (many-to-many association) --------------------------------
 class CollectionArticle(SQLModel, table=True):
     """Association table between collections and articles."""

--- a/src/meridiano/run_briefing.py
+++ b/src/meridiano/run_briefing.py
@@ -32,7 +32,13 @@ embedding_client = {
 }
 
 
-def call_deepseek_chat(prompt, model=config.LLM_CHAT_MODEL, system_prompt=None):
+# A reasoning model that exhausts its completion budget while still thinking returns
+# an empty string with finish_reason="length" instead of raising. Retrying once with a
+# bigger budget is the only way to tell that apart from a genuinely empty answer.
+EMPTY_RESPONSE_RETRY_FACTOR = 2
+
+
+def call_deepseek_chat(prompt, model=config.LLM_CHAT_MODEL, system_prompt=None, max_tokens=None):
     """Calls the LLM API (Deepseek, Ollama, etc)."""
     messages = []
     if system_prompt:
@@ -40,10 +46,12 @@ def call_deepseek_chat(prompt, model=config.LLM_CHAT_MODEL, system_prompt=None):
 
     messages.append({"role": "user", "content": prompt})
 
+    budget = max_tokens or config.LLM_MAX_TOKENS
+
     completion_kwargs = {
         "model": model,
         "messages": messages,
-        "max_tokens": 2048,
+        "max_tokens": budget,
         "temperature": 0.7,
     }
 
@@ -61,14 +69,31 @@ def call_deepseek_chat(prompt, model=config.LLM_CHAT_MODEL, system_prompt=None):
             completion_kwargs["api_base"] = ollama_base
             # print(f"DEBUG: Using Ollama API Base: {ollama_base}")
 
-    try:
-        response = litellm.completion(**completion_kwargs)
-        return response["choices"][0]["message"]["content"].strip()
-    except Exception as e:
-        print(f"Error calling Deepseek Chat API: {e}")
-        # Implement retry logic or better error handling here if needed
-        time.sleep(1)  # Basic backoff
-        return None
+    for attempt in range(2):
+        completion_kwargs["max_tokens"] = budget
+        try:
+            response = litellm.completion(**completion_kwargs)
+        except Exception as e:
+            print(f"Error calling Deepseek Chat API: {e}")
+            # Implement retry logic or better error handling here if needed
+            time.sleep(1)  # Basic backoff
+            return None
+
+        choice = response["choices"][0]
+        content = (choice["message"].get("content") or "").strip()
+        if content:
+            return content
+
+        finish_reason = choice.get("finish_reason")
+        if finish_reason != "length" or attempt:
+            print(f"Warning: LLM returned an empty response (finish_reason={finish_reason}).")
+            return None
+
+        # The whole budget went to reasoning tokens; nothing was left to answer with.
+        budget *= EMPTY_RESPONSE_RETRY_FACTOR
+        print(f"LLM spent its entire completion budget reasoning. Retrying with max_tokens={budget}.")
+
+    return None
 
 
 def get_deepseek_embedding(text, model=config.EMBEDDING_MODEL):
@@ -90,6 +115,60 @@ def get_deepseek_embedding(text, model=config.EMBEDDING_MODEL):
     except Exception as e:
         print(f"Error calling Embedding API: {e}")
         return None
+
+
+# --- Brief Sources ---
+
+# Cluster analyses open with a `TOPIC: ...` line that names the story. It is split
+# off before the analysis reaches synthesis, so it never lands in the brief text --
+# it only becomes a heading in the source list under the brief.
+TOPIC_LINE_RE = re.compile(r"^\s*\**\s*TOPIC\s*:?\**\s*(.+?)\s*$", re.IGNORECASE)
+
+# How many summaries of a cluster are shown to the model, and how many clusters
+# reach the final synthesis prompt.
+MAX_SUMMARIES_PER_CLUSTER = 10
+MAX_CLUSTERS_IN_BRIEF = 5
+
+
+def split_topic_line(analysis):
+    """Pulls a leading 'TOPIC: ...' line off a cluster analysis.
+
+    Returns (topic or None, analysis without that line). Models that ignore the
+    instruction simply yield (None, analysis).
+    """
+    lines = analysis.lstrip().split("\n")
+    match = TOPIC_LINE_RE.match(lines[0]) if lines else None
+    if not match:
+        return None, analysis
+
+    topic = match.group(1).strip().strip("*").strip('"').strip()
+    return (topic or None), "\n".join(lines[1:]).lstrip()
+
+
+def build_article_links(clusters):
+    """Builds the BriefArticle rows for the clusters that reached the brief.
+
+    Only the articles shown to the model are listed, so the source list never
+    credits an article the analysis never saw. An article that landed in two
+    clusters is attributed to the first one.
+    """
+    links = []
+    seen = set()
+
+    for index, cluster in enumerate(clusters):
+        for article in cluster["referenced_articles"]:
+            article_id = article["id"]
+            if article_id in seen:
+                continue
+            seen.add(article_id)
+            links.append(
+                {
+                    "article_id": article_id,
+                    "cluster_index": index,
+                    "cluster_topic": cluster["topic"],
+                }
+            )
+    return links
 
 
 # --- Core Functions ---
@@ -367,6 +446,9 @@ def generate_brief(feed_profile, effective_config):
         "PROMPT_CLUSTER_ANALYSIS",  # Look for this constant
         config.PROMPT_CLUSTER_ANALYSIS,  # Fallback to default if not found
     )
+    # The topic rule lives outside the template so it still applies to the feed
+    # profiles that override PROMPT_CLUSTER_ANALYSIS.
+    cluster_topic_rule = getattr(effective_config, "PROMPT_CLUSTER_TOPIC_RULE", config.PROMPT_CLUSTER_TOPIC_RULE)
     print(f"DEBUG: Using Cluster Analysis Prompt Template:\n'''{cluster_analysis_prompt_template[:100]}...'''")  # Debug
 
     for i in range(n_clusters):  # Use the actual n_clusters determined
@@ -374,26 +456,36 @@ def generate_brief(feed_profile, effective_config):
         if len(cluster_indices) == 0:
             continue  # Skip empty clusters
 
-        cluster_summaries = [summaries[idx] for idx in cluster_indices]
-        print(f"  Analyzing Cluster {i} ({len(cluster_summaries)} articles)")
+        cluster_articles = [articles[idx] for idx in cluster_indices]
+        # Only the articles actually shown to the model are credited as sources.
+        referenced_articles = cluster_articles[:MAX_SUMMARIES_PER_CLUSTER]
+        print(f"  Analyzing Cluster {i} ({len(cluster_articles)} articles)")
 
-        MAX_SUMMARIES_PER_CLUSTER = 10  # Consider making this configurable too?
-        cluster_summaries_text = "\n\n".join([f"- {s}" for s in cluster_summaries[:MAX_SUMMARIES_PER_CLUSTER]])
+        cluster_summaries_text = "\n\n".join(
+            [f"- {summaries[idx]}" for idx in cluster_indices[:MAX_SUMMARIES_PER_CLUSTER]]
+        )
 
         # *** Format the chosen prompt template ***
         analysis_prompt = cluster_analysis_prompt_template.format(
             cluster_summaries_text=cluster_summaries_text, feed_profile=feed_profile
         )
+        analysis_prompt = f"{analysis_prompt}\n{cluster_topic_rule}"
 
         # *** Call LLM with the formatted prompt ***
         # System prompt could also be configurable
         cluster_analysis = call_deepseek_chat(analysis_prompt, model=chat_model)
 
         if cluster_analysis:
+            topic, cluster_analysis = split_topic_line(cluster_analysis)
             # (Consider adding more robust filtering of non-analysis responses)
-            if "unrelated" not in cluster_analysis.lower() or len(cluster_summaries) > 2:
+            if "unrelated" not in cluster_analysis.lower() or len(cluster_articles) > 2:
                 cluster_analyses.append(
-                    {"topic": f"Cluster {i + 1}", "analysis": cluster_analysis, "size": len(cluster_summaries)}
+                    {
+                        "topic": topic,
+                        "analysis": cluster_analysis,
+                        "size": len(cluster_articles),
+                        "referenced_articles": referenced_articles,
+                    }
                 )
         time.sleep(1)  # Rate limiting
     # --- End Analyze each cluster ---
@@ -411,8 +503,10 @@ def generate_brief(feed_profile, effective_config):
     )  # Fallback
     print(f"DEBUG: Using Brief Synthesis Prompt Template:\n'''{brief_synthesis_prompt_template[:100]}...'''")
 
+    top_clusters = cluster_analyses[:MAX_CLUSTERS_IN_BRIEF]
+
     cluster_analyses_text = ""
-    for i, cluster in enumerate(cluster_analyses[:5]):
+    for i, cluster in enumerate(top_clusters):
         cluster_analyses_text += (
             f"--- Cluster {i + 1} ({cluster['size']} articles) ---\nAnalysis: {cluster['analysis']}\n\n"
         )
@@ -423,7 +517,10 @@ def generate_brief(feed_profile, effective_config):
     final_brief_md = call_deepseek_chat(synthesis_prompt, model=chat_model)
 
     if final_brief_md:
-        database.save_brief(final_brief_md, article_ids, feed_profile)
+        # Only the clusters that reached the brief are credited as its sources.
+        database.save_brief(
+            final_brief_md, article_ids, feed_profile, article_links=build_article_links(top_clusters)
+        )
         print(f"--- Brief Generation Finished Successfully [{feed_profile}] ---")
     else:
         print(f"--- Brief Generation Failed [{feed_profile}]: Could not synthesize final brief. ---")

--- a/src/meridiano/static/css/style.css
+++ b/src/meridiano/static/css/style.css
@@ -110,6 +110,38 @@ hr {
     margin-top: 20px;
 }
 
+/* --- Brief Sources --- */
+.brief-sources {
+    margin-top: 35px;
+    padding-top: 15px;
+    border-top: 2px solid #eee;
+}
+
+.brief-sources > summary {
+    cursor: pointer;
+    padding: 5px 0;
+    font-size: 1.17em;
+    font-weight: bold;
+}
+
+.brief-sources-count {
+    color: #6c757d;
+    font-size: 0.8em;
+    font-weight: normal;
+}
+
+.brief-sources-topic {
+    margin: 20px 0 0;
+    color: #6c757d;
+    font-size: 0.9em;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.brief-sources .article-list {
+    margin-top: 10px;
+}
+
 /* --- Briefing List Styling --- */
 .brief-list {
     list-style-type: none;
@@ -1096,6 +1128,9 @@ html[data-theme="dark"] .brief-link:hover { color: #74c0fc; }
 html[data-theme="dark"] .brief-meta { color: #9aa0a6; }
 html[data-theme="dark"] .profile-link { color: #4dabf7; }
 html[data-theme="dark"] .profile-link:hover { background-color: #2b2f36; }
+html[data-theme="dark"] .brief-sources { border-top-color: #2b2f36; }
+html[data-theme="dark"] .brief-sources-count,
+html[data-theme="dark"] .brief-sources-topic { color: #9aa0a6; }
 html[data-theme="dark"] .profile-link.active { background-color: #495057; color: #f1f3f5; }
 html[data-theme="dark"] .brief-content a { color: #4dabf7; }
 html[data-theme="dark"] .brief-content a:hover { color: #74c0fc; }

--- a/src/meridiano/static/css/style.css
+++ b/src/meridiano/static/css/style.css
@@ -130,14 +130,6 @@ hr {
     font-weight: normal;
 }
 
-.brief-sources-topic {
-    margin: 20px 0 0;
-    color: #6c757d;
-    font-size: 0.9em;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-}
-
 .brief-sources .article-list {
     margin-top: 10px;
 }
@@ -1129,8 +1121,7 @@ html[data-theme="dark"] .brief-meta { color: #9aa0a6; }
 html[data-theme="dark"] .profile-link { color: #4dabf7; }
 html[data-theme="dark"] .profile-link:hover { background-color: #2b2f36; }
 html[data-theme="dark"] .brief-sources { border-top-color: #2b2f36; }
-html[data-theme="dark"] .brief-sources-count,
-html[data-theme="dark"] .brief-sources-topic { color: #9aa0a6; }
+html[data-theme="dark"] .brief-sources-count { color: #9aa0a6; }
 html[data-theme="dark"] .profile-link.active { background-color: #495057; color: #f1f3f5; }
 html[data-theme="dark"] .brief-content a { color: #4dabf7; }
 html[data-theme="dark"] .brief-content a:hover { color: #74c0fc; }

--- a/src/meridiano/templates/view_brief.html
+++ b/src/meridiano/templates/view_brief.html
@@ -13,8 +13,8 @@
             {{ brief_content|safe }}
         </div>
 
-        {% if source_groups %}
-        <details class="brief-sources" {% if sources_grouped %}open{% endif %}>
+        {% if source_articles %}
+        <details class="brief-sources" open>
             <summary>
                 <i class="fas fa-link"></i> Sources
                 <span class="brief-sources-count">
@@ -25,16 +25,11 @@
                     {%- endif %}
                 </span>
             </summary>
-            {% for group in source_groups %}
-                {% if group.topic %}
-                    <h4 class="brief-sources-topic">{{ group.topic }}</h4>
-                {% endif %}
-                <ul class="article-list">
-                    {% for article in group.articles %}
-                        {% include '_article_item.html' %}
-                    {% endfor %}
-                </ul>
-            {% endfor %}
+            <ul class="article-list">
+                {% for article in source_articles %}
+                    {% include '_article_item.html' %}
+                {% endfor %}
+            </ul>
         </details>
         {% endif %}
     </div>

--- a/src/meridiano/templates/view_brief.html
+++ b/src/meridiano/templates/view_brief.html
@@ -12,6 +12,31 @@
         <div class="brief-content">
             {{ brief_content|safe }}
         </div>
+
+        {% if source_groups %}
+        <details class="brief-sources" {% if sources_grouped %}open{% endif %}>
+            <summary>
+                <i class="fas fa-link"></i> Sources
+                <span class="brief-sources-count">
+                    {%- if source_count < source_total %}
+                        ({{ source_count }} of {{ source_total }})
+                    {%- else %}
+                        ({{ source_count }})
+                    {%- endif %}
+                </span>
+            </summary>
+            {% for group in source_groups %}
+                {% if group.topic %}
+                    <h4 class="brief-sources-topic">{{ group.topic }}</h4>
+                {% endif %}
+                <ul class="article-list">
+                    {% for article in group.articles %}
+                        {% include '_article_item.html' %}
+                    {% endfor %}
+                </ul>
+            {% endfor %}
+        </details>
+        {% endif %}
     </div>
 </body>
 </html>

--- a/tests/integration/test_run_briefing.py
+++ b/tests/integration/test_run_briefing.py
@@ -316,3 +316,175 @@ def test_empty_feed_profile(setup_integration):
             output = captured_output.getvalue()
             assert "Skipping scrape stage: No RSS_FEEDS found" in output
             assert "Skipping generate stage: No RSS_FEEDS found" in output
+
+
+def _completion(content, finish_reason="stop"):
+    """Builds a litellm-shaped reply."""
+    return {"choices": [{"message": {"content": content}, "finish_reason": finish_reason}]}
+
+
+class TestChatCompletionBudget:
+    """Reasoning models burn the completion budget before answering; see LLM_MAX_TOKENS."""
+
+    def test_uses_the_configured_budget(self, setup_integration):
+        """Test that the default budget comes from config rather than a hardcoded value."""
+        mock_completion = setup_integration["mock_completion"]
+        mock_completion.side_effect = None
+        mock_completion.return_value = _completion("An answer.")
+
+        with patch("meridiano.config_base.LLM_MAX_TOKENS", 4321):
+            assert run_briefing.call_deepseek_chat("Prompt") == "An answer."
+
+        assert mock_completion.call_args.kwargs["max_tokens"] == 4321
+
+    def test_retries_with_a_bigger_budget_when_reasoning_ate_it_all(self, setup_integration):
+        """Test that an empty finish_reason='length' reply is retried, not given up on."""
+        mock_completion = setup_integration["mock_completion"]
+        mock_completion.side_effect = [
+            _completion("", finish_reason="length"),
+            _completion("The real brief."),
+        ]
+
+        with patch("meridiano.config_base.LLM_MAX_TOKENS", 1000):
+            assert run_briefing.call_deepseek_chat("Prompt") == "The real brief."
+
+        budgets = [call.kwargs["max_tokens"] for call in mock_completion.call_args_list]
+        assert budgets == [1000, 1000 * run_briefing.EMPTY_RESPONSE_RETRY_FACTOR]
+
+    def test_gives_up_after_one_retry(self, setup_integration):
+        """Test that a persistently empty response ends the loop instead of spinning."""
+        mock_completion = setup_integration["mock_completion"]
+        mock_completion.side_effect = [
+            _completion("", finish_reason="length"),
+            _completion("", finish_reason="length"),
+        ]
+
+        assert run_briefing.call_deepseek_chat("Prompt") is None
+        assert mock_completion.call_count == 2
+
+    def test_empty_answer_that_is_not_truncated_is_not_retried(self, setup_integration):
+        """Test that a model which simply answered nothing is not billed for a retry."""
+        mock_completion = setup_integration["mock_completion"]
+        mock_completion.side_effect = None
+        mock_completion.return_value = _completion("", finish_reason="stop")
+
+        assert run_briefing.call_deepseek_chat("Prompt") is None
+        assert mock_completion.call_count == 1
+
+    def test_missing_content_key_is_treated_as_empty(self, setup_integration):
+        """Test that a reply carrying only reasoning_content does not raise."""
+        mock_completion = setup_integration["mock_completion"]
+        mock_completion.side_effect = None
+        mock_completion.return_value = {
+            "choices": [{"message": {"reasoning_content": "thinking..."}, "finish_reason": "stop"}]
+        }
+
+        assert run_briefing.call_deepseek_chat("Prompt") is None
+
+
+class TestSplitTopicLine:
+    """The TOPIC line is a source-list heading, not part of the brief text."""
+
+    def test_extracts_the_topic_and_drops_the_line(self):
+        """Test that the heading is lifted off and the analysis keeps the rest."""
+        topic, analysis = run_briefing.split_topic_line("TOPIC: Chips And Fabs\n\nThe real analysis.")
+
+        assert topic == "Chips And Fabs"
+        assert analysis == "The real analysis."
+
+    def test_tolerates_markdown_emphasis_and_quotes(self):
+        """Test that a model wrapping the line in ** or quotes still parses."""
+        topic, analysis = run_briefing.split_topic_line('**TOPIC:** "Cloud Outages"\n\nBody.')
+
+        assert topic == "Cloud Outages"
+        assert analysis == "Body."
+
+    def test_missing_topic_line_leaves_the_analysis_untouched(self):
+        """Test that a model ignoring the instruction costs nothing."""
+        topic, analysis = run_briefing.split_topic_line("Straight into the analysis.")
+
+        assert topic is None
+        assert analysis == "Straight into the analysis."
+
+
+class TestBuildArticleLinks:
+    """Only articles the model actually saw may be credited as sources."""
+
+    def test_numbers_clusters_and_carries_their_topic(self):
+        """Test that link rows record the cluster order and heading."""
+        clusters = [
+            {"topic": "First", "referenced_articles": [{"id": 1}, {"id": 2}]},
+            {"topic": "Second", "referenced_articles": [{"id": 3}]},
+        ]
+
+        links = run_briefing.build_article_links(clusters)
+
+        assert links == [
+            {"article_id": 1, "cluster_index": 0, "cluster_topic": "First"},
+            {"article_id": 2, "cluster_index": 0, "cluster_topic": "First"},
+            {"article_id": 3, "cluster_index": 1, "cluster_topic": "Second"},
+        ]
+
+    def test_an_article_in_two_clusters_is_listed_once(self):
+        """Test that the first cluster wins, so the source list has no duplicates."""
+        clusters = [
+            {"topic": "First", "referenced_articles": [{"id": 1}]},
+            {"topic": "Second", "referenced_articles": [{"id": 1}, {"id": 2}]},
+        ]
+
+        links = run_briefing.build_article_links(clusters)
+
+        assert [(link["article_id"], link["cluster_index"]) for link in links] == [(1, 0), (2, 1)]
+
+
+def _seed_processed_articles(count, feed_profile="test"):
+    """Adds articles that are already summarized and embedded, ready for briefing."""
+    article_ids = []
+    for i in range(1, count + 1):
+        article_id = database.add_article(
+            f"http://example.com/src{i}",
+            f"Source Article {i}",
+            datetime.now(),
+            f"Source {i}",
+            "Raw content.",
+            feed_profile,
+            None,
+        )
+        database.update_article_processing(article_id, f"Summary {i}.", [i * 0.1, i * 0.2, i * 0.3])
+        article_ids.append(article_id)
+    return article_ids
+
+
+def test_generate_brief_records_its_sources(setup_integration):
+    """A generated brief links the articles its clusters were built from."""
+    mock_completion = setup_integration["mock_completion"]
+    feed_profile = "test"
+    _seed_processed_articles(6, feed_profile)
+
+    def chat_side_effect(*args, **kwargs):
+        user_content = kwargs.get("messages", [])[-1]["content"]
+        if "core event or topic" in user_content:
+            content = "TOPIC: Seeded Topic\n\nCluster analysis body."
+        else:
+            content = "# Final Brief\n\n- Point one\n- Point two"
+        return {"choices": [{"message": {"content": content}}]}
+
+    mock_completion.side_effect = chat_side_effect
+
+    effective_config = MagicMock()
+    effective_config.PROMPT_CLUSTER_ANALYSIS = run_briefing.config.PROMPT_CLUSTER_ANALYSIS
+    effective_config.PROMPT_BRIEF_SYNTHESIS = run_briefing.config.PROMPT_BRIEF_SYNTHESIS
+    effective_config.PROMPT_CLUSTER_TOPIC_RULE = run_briefing.config.PROMPT_CLUSTER_TOPIC_RULE
+    effective_config.LLM_CHAT_MODEL = "test-model"
+
+    with patch("meridiano.config_base.MIN_ARTICLES_FOR_BRIEFING", 2):
+        run_briefing.generate_brief(feed_profile, effective_config)
+
+    brief = database.get_all_briefs_metadata(feed_profile=feed_profile)[0]
+    links = database.get_brief_article_links(brief["id"])
+
+    assert links, "the brief should record the articles it was built from"
+    # The TOPIC line is a heading only; it must not survive into the brief text.
+    assert "TOPIC:" not in database.get_brief_by_id(brief["id"])["brief_markdown"]
+    assert all(link["cluster_topic"] == "Seeded Topic" for link in links)
+    assert len(links) == len({link["article_id"] for link in links})

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -303,8 +303,8 @@ class TestViewBriefRoute:
         """Test that an unknown brief id is a 404."""
         assert client.get("/brief/9999").status_code == 404
 
-    def test_sources_are_grouped_by_cluster_topic(self, client, sample_article_data):
-        """Test that each cluster becomes its own titled group in the source list."""
+    def test_cluster_topics_are_not_rendered(self, client, sample_article_data):
+        """Test that clustered sources collapse into one list with no topic headings."""
         first, second = self._seed_articles(sample_article_data, 2)
         with app.app_context():
             brief_id = save_brief(
@@ -320,27 +320,37 @@ class TestViewBriefRoute:
         response = client.get(f"/brief/{brief_id}")
 
         assert response.status_code == 200
-        assert b"Chips And Fabs" in response.data
-        assert b"Cloud Outages" in response.data
+        assert b"Chips And Fabs" not in response.data
+        assert b"Cloud Outages" not in response.data
+        assert response.data.count(b'<ul class="article-list">') == 1
         assert b"Source Article 1" in response.data
         assert b"Source Article 2" in response.data
 
-    def test_untitled_cluster_renders_without_a_heading(self, client, sample_article_data):
-        """Test that a missing topic still lists its articles."""
-        (article_id,) = self._seed_articles(sample_article_data, 1)
+    def test_clustered_sources_are_ranked_by_impact_across_clusters(self, client, sample_article_data):
+        """Test that impact rank wins over cluster order in the flattened list."""
+        article_ids = self._seed_articles(sample_article_data, 3)
         with app.app_context():
+            from meridiano.models import Article, get_session
+
+            with get_session() as session:
+                for article_id, score in zip(article_ids, [2, 9, None]):
+                    session.get(Article, article_id).impact_score = score
+                session.commit()
             brief_id = save_brief(
                 "# Brief",
-                [article_id],
+                article_ids,
                 "test",
-                article_links=[{"article_id": article_id, "cluster_index": 0, "cluster_topic": None}],
+                article_links=[
+                    {"article_id": article_ids[0], "cluster_index": 0, "cluster_topic": "First"},
+                    {"article_id": article_ids[2], "cluster_index": 0, "cluster_topic": "First"},
+                    {"article_id": article_ids[1], "cluster_index": 1, "cluster_topic": "Second"},
+                ],
             )
 
-        response = client.get(f"/brief/{brief_id}")
+        html = client.get(f"/brief/{brief_id}").get_data(as_text=True)
 
-        assert response.status_code == 200
-        assert b"brief-sources-topic" not in response.data
-        assert b"Source Article 1" in response.data
+        positions = [html.index(f"Source Article {i}") for i in (2, 1, 3)]
+        assert positions == sorted(positions), "expected impact 9, then 2, then unscored"
 
     def test_legacy_brief_falls_back_to_contributing_ids(self, client, sample_article_data):
         """Test that a brief predating source tracking still lists its articles."""
@@ -384,8 +394,8 @@ class TestViewBriefRoute:
         assert b"(2 of 5)" in response.data
         assert b"Source Article 3" not in response.data
 
-    def test_grouped_sources_open_by_default(self, client, sample_article_data):
-        """Test that tracked sources are expanded while legacy ones stay collapsed."""
+    def test_sources_open_by_default(self, client, sample_article_data):
+        """Test that the source list is expanded for tracked and legacy briefs alike."""
         (article_id,) = self._seed_articles(sample_article_data, 1)
         with app.app_context():
             tracked = save_brief(
@@ -396,8 +406,8 @@ class TestViewBriefRoute:
             )
             legacy = save_brief("# Brief", [article_id], "test")
 
-        assert b"<details class=\"brief-sources\" open>" in client.get(f"/brief/{tracked}").data
-        assert b"<details class=\"brief-sources\" open>" not in client.get(f"/brief/{legacy}").data
+        for brief_id in (tracked, legacy):
+            assert b"<details class=\"brief-sources\" open>" in client.get(f"/brief/{brief_id}").data
 
     def test_brief_without_sources_omits_the_section(self, client):
         """Test that a brief with no surviving articles renders no Sources block."""
@@ -427,7 +437,7 @@ class TestViewBriefRoute:
 
         assert response.status_code == 200
         assert b"Source Article 1" in response.data
-        assert b"Gone" not in response.data
+        assert b"(1)" in response.data
 
 
 class TestHeaderActiveLinks:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,6 +4,7 @@ Tests for Flask application routes.
 
 import os
 import sys
+from unittest.mock import patch
 
 import pytest
 
@@ -14,7 +15,12 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../s
 # Import app after setting up test database
 os.environ["DATABASE_URL"] = "sqlite:///:memory:"
 from meridiano.app import app
-from meridiano.database import add_article, create_collection, get_collection_by_id
+from meridiano.database import (
+    add_article,
+    create_collection,
+    get_collection_by_id,
+    save_brief,
+)
 
 
 @pytest.fixture
@@ -270,6 +276,158 @@ class TestCollectionsRoutes:
         response = client.post("/collection/9999/toggle_archive", follow_redirects=True)
         assert response.status_code == 200
         assert b"Collection with ID 9999 not found" in response.data
+
+
+class TestViewBriefRoute:
+    """Tests for the brief page and the source list underneath it."""
+
+    def _seed_articles(self, sample_article_data, count):
+        """Adds ``count`` articles and returns their ids."""
+        article_ids = []
+        with app.app_context():
+            for i in range(1, count + 1):
+                article_ids.append(
+                    add_article(
+                        f"https://example.com/src{i}",
+                        f"Source Article {i}",
+                        sample_article_data["published_date"],
+                        sample_article_data["feed_source"],
+                        sample_article_data["raw_content"],
+                        sample_article_data["feed_profile"],
+                        sample_article_data["image_url"],
+                    )
+                )
+        return article_ids
+
+    def test_brief_not_found(self, client):
+        """Test that an unknown brief id is a 404."""
+        assert client.get("/brief/9999").status_code == 404
+
+    def test_sources_are_grouped_by_cluster_topic(self, client, sample_article_data):
+        """Test that each cluster becomes its own titled group in the source list."""
+        first, second = self._seed_articles(sample_article_data, 2)
+        with app.app_context():
+            brief_id = save_brief(
+                "# Brief",
+                [first, second],
+                "test",
+                article_links=[
+                    {"article_id": first, "cluster_index": 0, "cluster_topic": "Chips And Fabs"},
+                    {"article_id": second, "cluster_index": 1, "cluster_topic": "Cloud Outages"},
+                ],
+            )
+
+        response = client.get(f"/brief/{brief_id}")
+
+        assert response.status_code == 200
+        assert b"Chips And Fabs" in response.data
+        assert b"Cloud Outages" in response.data
+        assert b"Source Article 1" in response.data
+        assert b"Source Article 2" in response.data
+
+    def test_untitled_cluster_renders_without_a_heading(self, client, sample_article_data):
+        """Test that a missing topic still lists its articles."""
+        (article_id,) = self._seed_articles(sample_article_data, 1)
+        with app.app_context():
+            brief_id = save_brief(
+                "# Brief",
+                [article_id],
+                "test",
+                article_links=[{"article_id": article_id, "cluster_index": 0, "cluster_topic": None}],
+            )
+
+        response = client.get(f"/brief/{brief_id}")
+
+        assert response.status_code == 200
+        assert b"brief-sources-topic" not in response.data
+        assert b"Source Article 1" in response.data
+
+    def test_legacy_brief_falls_back_to_contributing_ids(self, client, sample_article_data):
+        """Test that a brief predating source tracking still lists its articles."""
+        article_ids = self._seed_articles(sample_article_data, 2)
+        with app.app_context():
+            brief_id = save_brief("# Brief", article_ids, "test")
+
+        response = client.get(f"/brief/{brief_id}")
+
+        assert response.status_code == 200
+        assert b"Source Article 1" in response.data
+        assert b"Source Article 2" in response.data
+
+    def test_legacy_sources_are_ranked_by_impact(self, client, sample_article_data):
+        """Test that a brief with no clusters still leads with its strongest story."""
+        article_ids = self._seed_articles(sample_article_data, 3)
+        with app.app_context():
+            from meridiano.models import Article, get_session
+
+            with get_session() as session:
+                for article_id, score in zip(article_ids, [2, 9, None]):
+                    session.get(Article, article_id).impact_score = score
+                session.commit()
+            brief_id = save_brief("# Brief", article_ids, "test")
+
+        html = client.get(f"/brief/{brief_id}").get_data(as_text=True)
+
+        positions = [html.index(f"Source Article {i}") for i in (2, 1, 3)]
+        assert positions == sorted(positions), "expected impact 9, then 2, then unscored"
+
+    def test_source_list_is_capped(self, client, sample_article_data):
+        """Test that a huge legacy id list is trimmed and the total is disclosed."""
+        article_ids = self._seed_articles(sample_article_data, 5)
+        with app.app_context():
+            brief_id = save_brief("# Brief", article_ids, "test")
+
+        with patch("meridiano.app.config.BRIEF_MAX_SOURCES", 2):
+            response = client.get(f"/brief/{brief_id}")
+
+        assert response.status_code == 200
+        assert b"(2 of 5)" in response.data
+        assert b"Source Article 3" not in response.data
+
+    def test_grouped_sources_open_by_default(self, client, sample_article_data):
+        """Test that tracked sources are expanded while legacy ones stay collapsed."""
+        (article_id,) = self._seed_articles(sample_article_data, 1)
+        with app.app_context():
+            tracked = save_brief(
+                "# Brief",
+                [article_id],
+                "test",
+                article_links=[{"article_id": article_id, "cluster_index": 0, "cluster_topic": "Topic"}],
+            )
+            legacy = save_brief("# Brief", [article_id], "test")
+
+        assert b"<details class=\"brief-sources\" open>" in client.get(f"/brief/{tracked}").data
+        assert b"<details class=\"brief-sources\" open>" not in client.get(f"/brief/{legacy}").data
+
+    def test_brief_without_sources_omits_the_section(self, client):
+        """Test that a brief with no surviving articles renders no Sources block."""
+        with app.app_context():
+            brief_id = save_brief("# Brief", [], "test")
+
+        response = client.get(f"/brief/{brief_id}")
+
+        assert response.status_code == 200
+        assert b"brief-sources" not in response.data
+
+    def test_deleted_source_article_is_skipped(self, client, sample_article_data):
+        """Test that a link pointing at a removed article does not break the page."""
+        (article_id,) = self._seed_articles(sample_article_data, 1)
+        with app.app_context():
+            brief_id = save_brief(
+                "# Brief",
+                [article_id],
+                "test",
+                article_links=[
+                    {"article_id": article_id, "cluster_index": 0, "cluster_topic": "Topic"},
+                    {"article_id": 999999, "cluster_index": 1, "cluster_topic": "Gone"},
+                ],
+            )
+
+        response = client.get(f"/brief/{brief_id}")
+
+        assert response.status_code == 200
+        assert b"Source Article 1" in response.data
+        assert b"Gone" not in response.data
 
 
 class TestHeaderActiveLinks:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -26,7 +26,9 @@ from meridiano.database import (
     get_all_articles,
     get_article_by_id,
     get_article_count_for_collection,
+    get_articles_by_ids,
     get_articles_for_collection,
+    get_brief_article_links,
     get_brief_by_id,
     get_collection_by_id,
     get_collections,
@@ -221,6 +223,168 @@ class TestSaveBrief:
         retrieved = get_brief_by_id(brief_id)
         assert retrieved is not None
         assert retrieved["contributing_article_ids"] == json.dumps([])
+
+
+class TestGetArticlesByIds:
+    """Tests for the bulk article lookup used by the brief source list."""
+
+    def _add(self, sample_article_data, suffix, title):
+        data = {**sample_article_data, "url": f"https://example.com/a{suffix}", "title": title}
+        return add_article(
+            data["url"],
+            data["title"],
+            data["published_date"],
+            data["feed_source"],
+            data["raw_content"],
+            data["feed_profile"],
+            data["image_url"],
+        )
+
+    def test_returns_articles_in_requested_order(self, sample_article_data):
+        """Test that results follow the id order given, not insertion order."""
+        first = self._add(sample_article_data, 1, "First")
+        second = self._add(sample_article_data, 2, "Second")
+
+        results = get_articles_by_ids([second, first])
+
+        assert [a["title"] for a in results] == ["Second", "First"]
+
+    def test_skips_missing_ids(self, sample_article_data):
+        """Test that ids with no row are dropped instead of raising."""
+        existing = self._add(sample_article_data, 1, "First")
+
+        results = get_articles_by_ids([existing, 999999])
+
+        assert [a["id"] for a in results] == [existing]
+
+    def test_deduplicates_ids(self, sample_article_data):
+        """Test that a repeated id yields a single row."""
+        existing = self._add(sample_article_data, 1, "First")
+
+        results = get_articles_by_ids([existing, existing])
+
+        assert len(results) == 1
+
+    def test_empty_input(self):
+        """Test that no ids means no query and no rows."""
+        assert get_articles_by_ids([]) == []
+
+
+class TestBriefArticleLinks:
+    """Tests for the source links recorded alongside a brief."""
+
+    @pytest.fixture
+    def scored_sources(self):
+        """Creates source articles with known impact scores, keyed by score."""
+        from datetime import datetime
+
+        from meridiano.models import Article
+
+        ids = {}
+        with get_session() as session:
+            for score in (3, 7, 9, None):
+                article = Article(
+                    url=f"https://example.com/src-{score}",
+                    title=f"Score {score}",
+                    published_date=datetime(2024, 1, 1),
+                    feed_source="Test Feed",
+                    raw_content="content",
+                    feed_profile="test",
+                    impact_score=score,
+                )
+                session.add(article)
+                session.commit()
+                session.refresh(article)
+                ids[score] = article.id
+        return ids
+
+    def test_save_brief_persists_article_links(self, scored_sources):
+        """Test that article links are written and read back in cluster order."""
+        first, second = scored_sources[9], scored_sources[7]
+        links = [
+            {"article_id": second, "cluster_index": 1, "cluster_topic": "Second Topic"},
+            {"article_id": first, "cluster_index": 0, "cluster_topic": "First Topic"},
+        ]
+
+        brief_id = save_brief("# Brief", [first, second], "test", article_links=links)
+
+        stored = get_brief_article_links(brief_id)
+        assert [link["article_id"] for link in stored] == [first, second]
+        assert [link["cluster_topic"] for link in stored] == ["First Topic", "Second Topic"]
+
+    def test_links_are_ranked_by_impact_within_a_cluster(self, scored_sources):
+        """Test that the strongest story in a cluster is listed first."""
+        links = [
+            {"article_id": scored_sources[3], "cluster_index": 0, "cluster_topic": "Topic"},
+            {"article_id": scored_sources[9], "cluster_index": 0, "cluster_topic": "Topic"},
+            {"article_id": scored_sources[7], "cluster_index": 0, "cluster_topic": "Topic"},
+        ]
+
+        brief_id = save_brief("# Brief", [], "test", article_links=links)
+
+        stored = get_brief_article_links(brief_id)
+        assert [link["article_id"] for link in stored] == [
+            scored_sources[9],
+            scored_sources[7],
+            scored_sources[3],
+        ]
+
+    def test_unscored_articles_sort_last(self, scored_sources):
+        """Test that a NULL impact score does not outrank a real one."""
+        links = [
+            {"article_id": scored_sources[None], "cluster_index": 0},
+            {"article_id": scored_sources[3], "cluster_index": 0},
+        ]
+
+        brief_id = save_brief("# Brief", [], "test", article_links=links)
+
+        stored = get_brief_article_links(brief_id)
+        assert [link["article_id"] for link in stored] == [scored_sources[3], scored_sources[None]]
+
+    def test_cluster_order_beats_impact_score(self, scored_sources):
+        """Test that ranking happens inside a cluster, never across clusters."""
+        links = [
+            {"article_id": scored_sources[3], "cluster_index": 0, "cluster_topic": "First"},
+            {"article_id": scored_sources[9], "cluster_index": 1, "cluster_topic": "Second"},
+        ]
+
+        brief_id = save_brief("# Brief", [], "test", article_links=links)
+
+        stored = get_brief_article_links(brief_id)
+        assert [link["article_id"] for link in stored] == [scored_sources[3], scored_sources[9]]
+
+    def test_save_brief_without_links(self):
+        """Test that omitting links leaves the brief with no source rows."""
+        brief_id = save_brief("# Brief", [1, 2], "test")
+
+        assert get_brief_article_links(brief_id) == []
+
+    def test_links_are_scoped_to_their_brief(self, scored_sources):
+        """Test that one brief's links never leak into another's source list."""
+        first_article, second_article = scored_sources[9], scored_sources[7]
+        first = save_brief("# One", [], "test", article_links=[{"article_id": first_article, "cluster_index": 0}])
+        second = save_brief("# Two", [], "test", article_links=[{"article_id": second_article, "cluster_index": 0}])
+
+        assert [link["article_id"] for link in get_brief_article_links(first)] == [first_article]
+        assert [link["article_id"] for link in get_brief_article_links(second)] == [second_article]
+
+    def test_missing_topic_is_stored_as_none(self, scored_sources):
+        """Test that a model that ignored the TOPIC line yields an untitled group."""
+        article_id = scored_sources[9]
+        brief_id = save_brief("# Brief", [], "test", article_links=[{"article_id": article_id, "cluster_index": 0}])
+
+        assert get_brief_article_links(brief_id)[0]["cluster_topic"] is None
+
+    def test_link_to_a_deleted_article_is_dropped(self, scored_sources):
+        """Test that a source which no longer exists is not reported."""
+        links = [
+            {"article_id": scored_sources[9], "cluster_index": 0},
+            {"article_id": 999999, "cluster_index": 0},
+        ]
+
+        brief_id = save_brief("# Brief", [], "test", article_links=links)
+
+        assert [link["article_id"] for link in get_brief_article_links(brief_id)] == [scored_sources[9]]
 
 
 class TestCollections:


### PR DESCRIPTION
## O quê

Adiciona uma seção **Fontes** embaixo de cada briefing, listando os artigos que realmente alimentaram a análise — numa única lista ordenada por impact score.

Hoje o briefing não mostra de onde veio a informação. `contributing_article_ids` já guardava algo, mas incluía todo artigo da janela de tempo, inclusive os que nunca chegaram ao LLM.

## Detalhes

- Nova tabela de associação `BriefArticle` (`brief_id`, `article_id`, `cluster_index`, `cluster_topic`). Só entram os artigos que foram de fato enviados ao modelo, então a lista de fontes nunca promete um artigo que a análise não viu.
- `save_brief()` grava os vínculos; `get_brief_article_links()` os lê de volta.
- A view do briefing monta **uma lista só**, ordenada por impact score decrescente, com os não pontuados no fim. O cluster de origem não quebra mais a lista em subseções.
- `BRIEF_MAX_SOURCES` (padrão 60) limita a lista. O corte pega os N mais fortes globalmente.
- Briefings antigos, gerados antes do rastreamento de fontes, caem no `contributing_article_ids` e usam exatamente o mesmo caminho de código e a mesma ordenação.
- A seção é um `<details>` aberto por padrão, reaproveitando o `_article_item.html` da lista de artigos (imagem, badge de perfil, impact score, resumo), com estilo para o tema escuro.

## Junto nesse PR

- `LLM_MAX_TOKENS` (padrão 16384, configurável por env). Modelos com reasoning gastam o orçamento de completion raciocinando **antes** de escrever a resposta, então um teto baixo volta como string vazia com `finish_reason="length"` em vez de erro. Sem isso, os briefings saíam vazios aqui.
- `PROMPT_CLUSTER_TOPIC_RULE` pede ao modelo uma linha `TOPIC: ...` por cluster. A linha é removida antes da análise ser usada e o tópico fica guardado em `cluster_topic`. Hoje ele não é renderizado — deixei gravado porque é barato e serve para agrupar/filtrar depois. Se preferir, tiro a regra do prompt e a coluna.

## Testes

`pytest` — 93 passando. Cobertura nova: gravação e leitura dos vínculos brief↔artigo, ordenação por impact score (com clusters e no fallback legado), o limite de `BRIEF_MAX_SOURCES` com o rótulo "(X de Y)", artigo deletado que some da lista sem quebrar a página, briefing sem fontes que não renderiza a seção, e o parse da linha `TOPIC:`.
